### PR TITLE
Add util to sort expected rows and round numeric values

### DIFF
--- a/common/bigquery/test-utils.js
+++ b/common/bigquery/test-utils.js
@@ -78,7 +78,6 @@ function sortByKeyAndRound (list, orderKey, roundedKeys, precision=10) {
     list = list.sort((a, b) => (a[orderKey] > b[orderKey]) ? 1 : -1);
     for (let row of list) {
         for (let roundKey of roundedKeys) {
-            console.log('round ',roundKey);
             if (row[roundKey]) {
                 row[roundKey] = row[roundKey].toPrecision(precision);
             }

--- a/common/bigquery/test-utils.js
+++ b/common/bigquery/test-utils.js
@@ -75,14 +75,16 @@ function sortByKey (list, key) {
 }
 
 function sortByKeyAndRound (list, orderKey, roundedKeys, precision=10) {
-    return list.sort((a, b) => (a[orderKey] > b[orderKey]) ? 1 : -1).map(row => {
+    list = list.sort((a, b) => (a[orderKey] > b[orderKey]) ? 1 : -1);
+    for (let row of list) {
         for (let roundKey of roundedKeys) {
+            console.log('round ',roundKey);
             if (row[roundKey]) {
                 row[roundKey] = row[roundKey].toPrecision(precision);
             }
-            return row;
         }
-    });
+    }
+    return list;
 }
 
 module.exports = {

--- a/common/bigquery/test-utils.js
+++ b/common/bigquery/test-utils.js
@@ -74,6 +74,17 @@ function sortByKey (list, key) {
     return list.sort((a, b) => (a[key] > b[key]) ? 1 : -1);
 }
 
+function sortByKeyAndRound (list, orderKey, roundedKeys, precision=10) {
+    return list.sort((a, b) => (a[orderKey] > b[orderKey]) ? 1 : -1).map(row => {
+        for (let roundKey of roundedKeys) {
+            if (row[roundKey]) {
+                row[roundKey] = row[roundKey].toPrecision(precision);
+            }
+            return row;
+        }
+    });
+}
+
 module.exports = {
     runQuery,
     loadTable,
@@ -82,5 +93,6 @@ module.exports = {
     readJSONFixture,
     writeJSONFixture,
     cancelJob,
-    sortByKey
+    sortByKey,
+    sortByKeyAndRound
 };


### PR DESCRIPTION
This is handy for comparing result rows in integration tests, given that order may not be specified and float number accuracy may vary.