### PR TITLE
Add redshift tiler dependencies

### DIFF
--- a/modules/quadkey/redshift/lib/__init__.py
+++ b/modules/quadkey/redshift/lib/__init__.py
@@ -153,6 +153,14 @@ def quadkey_from_quadint(quadint):
     return mercantile.quadkey(tile['x'], tile['y'], tile['z'])
 
 
+def bbox_quadkey(quadkey):
+    import mercantile
+
+    tile = mercantile.quadkey_to_tile(quadkey)
+    bounds = mercantile.bounds(tile.x, tile.y, tile.z)
+    return [bounds.west, bounds.south, bounds.east, bounds.north]
+
+
 def bbox(quadint):
     import mercantile
 

--- a/modules/quadkey/redshift/lib/__init__.py
+++ b/modules/quadkey/redshift/lib/__init__.py
@@ -187,3 +187,34 @@ def geojson_to_quadints(poly, limits):
         quadint_from_zxy(int(tile[2]), int(tile[0]), int(tile[1]))
         for tile in tilecover.get_tiles(poly, limits)
     ]
+
+
+def quadbin_from_zxy(z, x, y):
+    x = x << (32 - z)
+    y = y << (32 - z)
+
+    b = [
+        0x5555555555555555,
+        0x3333333333333333,
+        0x0F0F0F0F0F0F0F0F,
+        0x00FF00FF00FF00FF,
+        0x0000FFFF0000FFFF,
+    ]
+    s = [1, 2, 4, 8, 16]
+
+    x = (x | (x << s[4])) & b[4]
+    y = (y | (y << s[4])) & b[4]
+
+    x = (x | (x << s[3])) & b[3]
+    y = (y | (y << s[3])) & b[3]
+
+    x = (x | (x << s[2])) & b[2]
+    y = (y | (y << s[2])) & b[2]
+
+    x = (x | (x << s[1])) & b[1]
+    y = (y | (y << s[1])) & b[1]
+
+    x = (x | (x << s[0])) & b[0]
+    y = (y | (y << s[0])) & b[0]
+
+    return (z << 58) | ((x | (y << 1)) >> 6)

--- a/modules/quadkey/redshift/sql/__QUADBIN_FROMQUADINT.sql
+++ b/modules/quadkey/redshift/sql/__QUADBIN_FROMQUADINT.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION @@RS_PREFIX@@carto.__QUADBIN_FROMZXY
 RETURNS BIGINT
 STABLE
 AS $$
-    from @@RS_PREFIX@@tilerLib import quadbin_from_zxy
+    from @@RS_PREFIX@@quadkeyLib import quadbin_from_zxy
     import json
 
     zxy = json.loads(zxy)

--- a/modules/quadkey/redshift/sql/__QUADBIN_FROMQUADINT.sql
+++ b/modules/quadkey/redshift/sql/__QUADBIN_FROMQUADINT.sql
@@ -1,0 +1,27 @@
+
+----------------------------
+-- Copyright (C) 2022 CARTO
+----------------------------
+
+CREATE OR REPLACE FUNCTION @@RS_PREFIX@@carto.__QUADBIN_FROMZXY
+(zxy VARCHAR(MAX))
+-- (quadint)
+RETURNS BIGINT
+STABLE
+AS $$
+    from @@RS_PREFIX@@tilerLib import quadbin_from_zxy
+    import json
+
+    zxy = json.loads(zxy)
+
+    return quadbin_from_zxy(zxy['z'], zxy['x'], zxy['y'])
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION @@RS_PREFIX@@carto.__QUADBIN_FROMQUADINT
+(BIGINT)
+-- (quadint)
+RETURNS BIGINT
+STABLE
+AS $$
+    SELECT @@RS_PREFIX@@carto.__QUADBIN_FROMZXY(JSON_SERIALIZE(@@RS_PREFIX@@carto.QUADINT_TOZXY($1)))
+$$ LANGUAGE sql;

--- a/modules/quadkey/redshift/sql/__QUADINT_RESOLUTION.sql
+++ b/modules/quadkey/redshift/sql/__QUADINT_RESOLUTION.sql
@@ -1,0 +1,11 @@
+----------------------------
+-- Copyright (C) 2022 CARTO
+----------------------------
+
+CREATE OR REPLACE FUNCTION @@RS_PREFIX@@carto.__QUADINT_RESOLUTION
+(index BIGINT)
+RETURNS BIGINT
+STABLE
+AS $$
+    SELECT CAST($1 AS BIGINT) & CAST(31 AS BIGINT)
+$$ LANGUAGE sql;

--- a/modules/quadkey/redshift/sql/__QUADKEY_BBOX.sql
+++ b/modules/quadkey/redshift/sql/__QUADKEY_BBOX.sql
@@ -1,0 +1,25 @@
+----------------------------
+-- Copyright (C) 2022 CARTO
+----------------------------
+
+CREATE OR REPLACE FUNCTION @@RS_PREFIX@@carto.__QUADKEY_BBOX_INTERNAL
+(quadkey VARCHAR(MAX))
+RETURNS VARCHAR(MAX)
+STABLE
+AS $$
+    from @@RS_PREFIX@@quadkeyLib import bbox_quadkey
+    
+    if quadkey is None:
+        raise Exception('NULL argument passed to UDF')
+
+    return str(bbox_quadkey(quadkey))
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION @@RS_PREFIX@@carto.__QUADKEY_BBOX
+(VARCHAR(MAX))
+-- (quadkey)
+RETURNS SUPER
+STABLE
+AS $$
+    SELECT json_parse(@@RS_PREFIX@@carto.__QUADKEY_BBOX_INTERNAL($1))
+$$ LANGUAGE sql;


### PR DESCRIPTION
I'm adding `__QUADKEY_BBOX(my_qk)` calling directly the internal JS UDFs because when using `QUADINT_BBOX(QUADINT_FROMQUADKEY(my_qk))` Redshift complains about too many nested functions.

I'm using this PR to bring the implementation of `__QUADBIN_FROMQUADINT` to the module quadkey as well.