### PR TITLE
Add auxiliar methods for PG tests

### DIFF
--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -71,7 +71,7 @@ def floats_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
     return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
-numbers = re.compile(r'^(?:([-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?\,?)+$')
+numbers = re.compile(r'^(?:[-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?(?:\s*\,\s*(?:[-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?)*$')
 
 
 def split_numbers(n):

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -71,7 +71,7 @@ def floats_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
     return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
-numbers = re.compile(r"""
+floats_list = re.compile(r"""
     ^
     (?:[-+]?\d*\.?\d+)(?:E([-+]?\d+))?     # first float
     (?:                                    # optional sequence of:
@@ -82,7 +82,7 @@ numbers = re.compile(r"""
     """, re.IGNORECASE | re.VERBOSE)
 
 
-def split_numbers(n):
+def split_floats_list(n):
     return [float(x) for x in n.split(',')]
 
 
@@ -117,9 +117,9 @@ def dicts_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
                 if not floats_approx_equal(a_value, b_value, rel_tol, abs_tol):
                     return False
             elif a_type == str:
-                if numbers.match(a_value) and numbers.match(b_value):
-                    a_values = split_numbers(a_value)
-                    b_values = split_numbers(b_value)
+                if floats_list.match(a_value) and floats_list.match(b_value):
+                    a_values = split_floats_list(a_value)
+                    b_values = split_floats_list(b_value)
                     if not floats_list_approx_equal(
                         a_values, b_values, rel_tol, abs_tol
                     ):

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -95,37 +95,82 @@ def floats_list_approx_equal(alist, blist, rel_tol=1e-5, abs_tol=0.0):
     return True
 
 
-def dicts_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
+def values_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
+    return len(values_approx_diff(a, b, rel_tol, abs_tol, '', True)) == 0
+
+
+def values_approx_diff_message(indent, a, b, rel_tol=1e-5, abs_tol=0.0):
+    diffs = values_approx_diff(a, b, rel_tol, abs_tol)
+    return '\n'.join([indent + msg for msg in diffs])
+
+
+def lists_approx_diff(a, b, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first=False):
+    spec =  ' ' if key_prefix == '' else f' of "{key_prefix}" '
+    diffs = []
     if (a == b):
-        return True
+        return diffs
+    if len(a) != len(b):
+        diffs.append(f'Lengths{spec}differ')
+    else:
+        for i, (a_value, b_value) in enumerate(zip(a, b)):
+            item_desc = f'{key_prefix}[{i}]' if key_prefix != '' else f'element {i}'
+            diffs += values_approx_diff(a_value, b_value, rel_tol, abs_tol, item_desc, only_first)
+        if only_first and len(diffs) > 0:
+            return diffs
+    return diffs
+
+def values_approx_diff(a_value, b_value, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first=False):
+    spec =  ' ' if key_prefix == '' else f' of "{key_prefix}" '
+    diffs = []
+    if (a_value == b_value):
+        return diffs
+    a_type = type(a_value)
+    b_type = type(b_value)
+    if a_type != b_type:
+        diffs.append(f'Types{spec}differ')
+    if a_type == list:
+        diffs += lists_approx_diff(a_value, b_value, rel_tol, abs_tol, key_prefix)
+    elif a_type == tuple:
+        diffs += lists_approx_diff(list(a_value), list(b_value), rel_tol, abs_tol, key_prefix)
+    elif a_type == dict:
+        diffs += dicts_approx_diff(a_value, b_value, rel_tol, abs_tol, key_prefix)
+    elif a_type == float:
+        if not floats_approx_equal(a_value, b_value, rel_tol, abs_tol):
+            diffs.append(f'Values{spec}too different: {a_value} vs {b_value}')
+    elif a_type == str:
+        if floats_list.match(a_value) and floats_list.match(b_value):
+            a_values = split_floats(a_value)
+            b_values = split_floats(b_value)
+            if not floats_list_approx_equal(a_values, b_values, rel_tol, abs_tol):
+                diffs.append(f'Values{spec}too different: {a_value} vs {b_value}')
+        elif a_value != b_value:
+            diffs.append(f'Values{spec}differ: "{a_value}" vs "{b_value}"')
+    elif a_value != b_value:
+        diffs.append(f'Values{spec}differ: "{a_value}" vs "{b_value}"')
+    return diffs
+
+
+def dicts_approx_diff(a, b, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first=False):
+    if key_prefix != '':
+        key_prefix = key_prefix + '.'
+    diffs = []
+    if (a == b):
+        return diffs
     a_keys = a.keys()
     b_keys = b.keys()
     if (a_keys != b_keys):
-        return False
+        anotb_keys = [key for key in a_keys if not key in b_keys]
+        bnota_keys = [key for key in b_keys if not key in a_keys]
+        diffs += [f'Key "{key_prefix + key}" only in first' for key in anotb_keys]
+        diffs += [f'Key "{key_prefix + key}" only in second' for key in bnota_keys]
+        if only_first:
+            return diffs
     for key in a_keys:
+        if not key in b_keys:
+            continue
         a_value = a.get(key)
         b_value = b.get(key)
-        if a_value != b_value:
-            a_type = type(a_value)
-            b_type = type(b_value)
-            if a_type != b_type:
-                return False
-            if a_type == dict:
-                if not dicts_approx_equal(a_value, b_value, rel_tol, abs_tol):
-                    return False
-            elif a_type == float:
-                if not floats_approx_equal(a_value, b_value, rel_tol, abs_tol):
-                    return False
-            elif a_type == str:
-                if floats_list.match(a_value) and floats_list.match(b_value):
-                    a_values = split_floats_list(a_value)
-                    b_values = split_floats_list(b_value)
-                    if not floats_list_approx_equal(
-                        a_values, b_values, rel_tol, abs_tol
-                    ):
-                        return False
-                elif a_value != b_value:
-                    return False
-            elif a_value != b_value:
-                return False
-    return True
+        diffs += values_approx_diff(a_value, b_value, rel_tol, abs_tol, key_prefix + key, only_first)
+        if only_first and len(diffs) > 0:
+            return diffs
+    return diffs

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -79,8 +79,12 @@ def split_numbers(n):
 
 
 def floats_list_approx_equal(alist, blist, rel_tol=1e-5, abs_tol=0.0):
+    if len(alist) != len(blist):
+        return False
     for a, b in zip(alist, blist):
-        return floats_approx_equal(a, b, rel_tol, abs_tol)
+        if not floats_approx_equal(a, b, rel_tol, abs_tol):
+            return False
+    return True
 
 
 def dicts_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
@@ -108,9 +112,9 @@ def dicts_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
                 if numbers.match(a_value) and numbers.match(b_value):
                     a_values = split_numbers(a_value)
                     b_values = split_numbers(b_value)
-                    if len(a_values) != len(b_values) \
-                        or not floats_list_approx_equal(
-                            a_values, b_values, rel_tol, abs_tol):
+                    if not floats_list_approx_equal(
+                        a_values, b_values, rel_tol, abs_tol
+                    ):
                         return False
                 elif a_value != b_value:
                     return False

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -57,3 +57,9 @@ def upload_csv_to_postgres(table):
     gdf = gdf.set_geometry('geom')
     gdf = gdf.set_crs(epsg=4326)
     gdf.to_postgis(table, engine, if_exists='replace')
+
+
+def upload_nogeom_csv_to_postgres(table):
+    """Read a CSV file, convert to a DataFrame and upload to the DB"""
+    df = pd.read_csv(f'test/integration/fixtures/{table}.csv')
+    df.to_sql(table, engine, if_exists='replace')

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -118,4 +118,6 @@ def dicts_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
                         return False
                 elif a_value != b_value:
                     return False
+            elif a_value != b_value:
+                return False
     return True

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -71,7 +71,7 @@ def floats_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
     return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
-numbers = re.compile(r"^(?:([-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?\,?)+$")
+numbers = re.compile(r'^(?:([-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?\,?)+$')
 
 
 def split_numbers(n):
@@ -108,7 +108,9 @@ def dicts_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
                 if numbers.match(a_value) and numbers.match(b_value):
                     a_values = split_numbers(a_value)
                     b_values = split_numbers(b_value)
-                    if len(a_values) != len(b_values) or not floats_list_approx_equal(a_values, b_values, rel_tol, abs_tol):
+                    if len(a_values) != len(b_values) \
+                        or not floats_list_approx_equal(
+                            a_values, b_values, rel_tol, abs_tol):
                         return False
                 elif a_value != b_value:
                     return False

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -105,7 +105,7 @@ def values_approx_diff_message(indent, a, b, rel_tol=1e-5, abs_tol=0.0):
 
 
 def lists_approx_diff(a, b, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first=False):
-    spec =  ' ' if key_prefix == '' else f' of "{key_prefix}" '
+    spec = ' ' if key_prefix == '' else f' of "{key_prefix}" '
     diffs = []
     if (a == b):
         return diffs
@@ -114,13 +114,17 @@ def lists_approx_diff(a, b, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first
     else:
         for i, (a_value, b_value) in enumerate(zip(a, b)):
             item_desc = f'{key_prefix}[{i}]' if key_prefix != '' else f'element {i}'
-            diffs += values_approx_diff(a_value, b_value, rel_tol, abs_tol, item_desc, only_first)
+            diffs += values_approx_diff(
+                a_value, b_value, rel_tol, abs_tol, item_desc, only_first)
         if only_first and len(diffs) > 0:
             return diffs
     return diffs
 
-def values_approx_diff(a_value, b_value, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first=False):
-    spec =  ' ' if key_prefix == '' else f' of "{key_prefix}" '
+
+def values_approx_diff(
+    a_value, b_value, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first=False
+):
+    spec = ' ' if key_prefix == '' else f' of "{key_prefix}" '
     diffs = []
     if (a_value == b_value):
         return diffs
@@ -129,18 +133,21 @@ def values_approx_diff(a_value, b_value, rel_tol=1e-5, abs_tol=0.0, key_prefix='
     if a_type != b_type:
         diffs.append(f'Types{spec}differ')
     if a_type == list:
-        diffs += lists_approx_diff(a_value, b_value, rel_tol, abs_tol, key_prefix)
+        diffs += lists_approx_diff(
+            a_value, b_value, rel_tol, abs_tol, key_prefix, only_first)
     elif a_type == tuple:
-        diffs += lists_approx_diff(list(a_value), list(b_value), rel_tol, abs_tol, key_prefix)
+        diffs += lists_approx_diff(
+            list(a_value), list(b_value), rel_tol, abs_tol, key_prefix, only_first)
     elif a_type == dict:
-        diffs += dicts_approx_diff(a_value, b_value, rel_tol, abs_tol, key_prefix)
+        diffs += dicts_approx_diff(
+            a_value, b_value, rel_tol, abs_tol, key_prefix, only_first)
     elif a_type == float:
         if not floats_approx_equal(a_value, b_value, rel_tol, abs_tol):
             diffs.append(f'Values{spec}too different: {a_value} vs {b_value}')
     elif a_type == str:
         if floats_list.match(a_value) and floats_list.match(b_value):
-            a_values = split_floats(a_value)
-            b_values = split_floats(b_value)
+            a_values = split_floats_list(a_value)
+            b_values = split_floats_list(b_value)
             if not floats_list_approx_equal(a_values, b_values, rel_tol, abs_tol):
                 diffs.append(f'Values{spec}too different: {a_value} vs {b_value}')
         elif a_value != b_value:
@@ -159,18 +166,19 @@ def dicts_approx_diff(a, b, rel_tol=1e-5, abs_tol=0.0, key_prefix='', only_first
     a_keys = a.keys()
     b_keys = b.keys()
     if (a_keys != b_keys):
-        anotb_keys = [key for key in a_keys if not key in b_keys]
-        bnota_keys = [key for key in b_keys if not key in a_keys]
+        anotb_keys = [key for key in a_keys if key not in b_keys]
+        bnota_keys = [key for key in b_keys if key not in a_keys]
         diffs += [f'Key "{key_prefix + key}" only in first' for key in anotb_keys]
         diffs += [f'Key "{key_prefix + key}" only in second' for key in bnota_keys]
         if only_first:
             return diffs
     for key in a_keys:
-        if not key in b_keys:
+        if key not in b_keys:
             continue
         a_value = a.get(key)
         b_value = b.get(key)
-        diffs += values_approx_diff(a_value, b_value, rel_tol, abs_tol, key_prefix + key, only_first)
+        diffs += values_approx_diff(
+            a_value, b_value, rel_tol, abs_tol, key_prefix + key, only_first)
         if only_first and len(diffs) > 0:
             return diffs
     return diffs

--- a/common/postgres/test_utils/__init__.py
+++ b/common/postgres/test_utils/__init__.py
@@ -71,7 +71,15 @@ def floats_approx_equal(a, b, rel_tol=1e-5, abs_tol=0.0):
     return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
-numbers = re.compile(r'^(?:[-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?(?:\s*\,\s*(?:[-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?)*$')
+numbers = re.compile(r"""
+    ^
+    (?:[-+]?\d*\.?\d+)(?:E([-+]?\d+))?     # first float
+    (?:                                    # optional sequence of:
+        \s*\,\s*                             # separator
+        (?:[-+]?\d*\.?\d+)(?:E([-+]?\d+))?   # additional float
+    )*
+    $
+    """, re.IGNORECASE | re.VERBOSE)
 
 
 def split_numbers(n):


### PR DESCRIPTION
- [x] New method to upload test PG tables with no geometry
- [x] New method to compare dicts with numeric values approximately

The `dicts_approx_equal` compares dicts and makes comparisons of floats and strings that contain comma-separated lists of numbers approximate (recursively).