### PR TITLE
Small changes in BigQuery reorganization

### DIFF
--- a/clouds/bigquery/common/list_functions.js
+++ b/clouds/bigquery/common/list_functions.js
@@ -53,7 +53,7 @@ if (output.length) {
     }
     // Check global teardown
     const teardownfile = path.join(moduledir, 'global', 'teardown.js');
-    if (fs.existsSync(setupfile)) {
+    if (fs.existsSync(teardownfile)) {
         output.push(`--globalTeardown=${teardownfile}`)
     }
 }

--- a/clouds/bigquery/common/test-utils.js
+++ b/clouds/bigquery/common/test-utils.js
@@ -17,7 +17,7 @@ async function runQuery (query, options) {
 }
 
 function replaceBQPrefix (text) {
-    return text.replace(/@@BQ_DATASET@@/g, BQ_DATASET);
+    return text.replace(/@@BQ_DATASET@@/g, BQ_DATASET).replace(/@@BQ_PREFIX@@/g, BQ_PREFIX);
 }
 
 async function loadTable (tablename, filepath, columns, viewName) {

--- a/clouds/snowflake/common/list_functions.js
+++ b/clouds/snowflake/common/list_functions.js
@@ -52,7 +52,7 @@ if (output.length) {
     }
     // Check global teardown
     const teardownfile = path.join(moduledir, 'global', 'teardown.js');
-    if (fs.existsSync(setupfile)) {
+    if (fs.existsSync(teardownfile)) {
         output.push(`--globalTeardown=${teardownfile}`)
     }
 }


### PR DESCRIPTION
* Fix globalTeardown file name check
* Replace BQ_PREFIX also in test queries (needed [some cases](https://github.com/CartoDB/analytics-toolbox/blob/master/modules/data/bigquery/test/integration/DATAOBS_ENRICH_POLYGONS.test.js#L162))