### PR TITLE
change default compression to snappy in databricks optimized tables

### DIFF
--- a/clouds/databricks/CHANGELOG.md
+++ b/clouds/databricks/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2022.09.20] - 2022-09-20
+
+### All modules
+#### Changed
+- Set default compression codec to snappy
+
 ## [2022.09.15] - 2022-09-15
 
 ### All modules

--- a/clouds/databricks/libraries/scala/core/src/main/scala/com/carto/analyticstoolbox/spark/spatial/OptimizeSpatial.scala
+++ b/clouds/databricks/libraries/scala/core/src/main/scala/com/carto/analyticstoolbox/spark/spatial/OptimizeSpatial.scala
@@ -123,6 +123,6 @@ object OptimizeSpatial extends Serializable {
   val DEFAULT_GEOM_COLUMN: String       = "geom"
   val DEFAULT_ZOOM: Int                 = 8
   val DEFAULT_BLOCK_SIZE: Long          = 2097000
-  val DEFAULT_COMPRESSION: String       = "lz4"
+  val DEFAULT_COMPRESSION: String       = "snappy"
   val DEFAULT_MAX_RECORDS_PER_FILE: Int = 0
 }


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/258281/change-optimized-tables-to-snappy-in-databricks

The tables in the database carto_dev_data with geometries and carto index field (optimized) have been rewritten in snappy.
The default compression has been set to snappy

## Type of change

#### Changed

- Set default compression codec to snappy

# Acceptance

- `cd clouds/databricks`
- `make deploy`
- Optimize a table
![image](https://user-images.githubusercontent.com/91467822/191183108-35601d52-b3ce-4ce1-aca0-7113c2a25d35.png)
- The table created must be compressed with snappy
![image](https://user-images.githubusercontent.com/91467822/191183355-15b27444-405e-4883-ae10-02f66d7f9204.png)
- Create a map of the newly created table in builder
![image](https://user-images.githubusercontent.com/91467822/191184334-d8079fd7-4a07-48b7-b499-449776c981f8.png)
- Create a map of a migrated table
![image](https://user-images.githubusercontent.com/91467822/191184550-fdf8299e-67d4-4927-9540-21d1c238739d.png)
