### PR TITLE
change type returned by st_x and xt_y to double

### DIFF
--- a/clouds/databricks/CHANGELOG.md
+++ b/clouds/databricks/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2022.09.20] - 2022-09-21
+
+### Accessors
+#### Changed
+- Change type returned by ST_X and ST_Y to Double
+
 ## [2022.09.20] - 2022-09-20
 
 ### All modules

--- a/clouds/databricks/libraries/scala/Makefile
+++ b/clouds/databricks/libraries/scala/Makefile
@@ -7,7 +7,7 @@ PRODUCT ?= core
 COMMON_DIR = $(ROOT_DIR)/../../common
 SCALA_DIR ?= $(ROOT_DIR)
 JAR_DIR ?= $(SCALA_DIR)/$(PRODUCT)/target/scala-2.12
-JAR_DEPLOY_PATH = dbfs:/FileStore/jars-carto/$(DB_PREFIX)carto
+JAR_DEPLOY_PATH = dbfs:/FileStore/jars-carto/$(DB_PREFIX)carto-$(PRODUCT)
 SQL_PATH = $(JAR_DIR)/classes/sql/createUDFs.sql
 
 include $(COMMON_DIR)/Makefile
@@ -86,8 +86,8 @@ test:
 
 remove: check
 	echo "Removing libraries..."
-	databricks libraries uninstall --cluster-id $(DB_CLUSTER_ID) --jar $(JAR_DEPLOY_PATH)/analyticstoolbox-$(PRODUCT)-assembly-SNAPSHOT.jar
-	dbfs rm $(JAR_DEPLOY_PATH)/analyticstoolbox-$(PRODUCT)-assembly.jar
+	databricks libraries uninstall --cluster-id $(DB_CLUSTER_ID) --jar $(JAR_DEPLOY_PATH)/analyticstoolbox-$(PRODUCT)-assembly.jar
+	dbfs rm -r $(JAR_DEPLOY_PATH)/
 
 clean:
 	echo "Cleaning libraries..."

--- a/clouds/databricks/libraries/scala/core/src/main/scala/com/carto/analyticstoolbox/modules/accessors/ST_X.scala
+++ b/clouds/databricks/libraries/scala/core/src/main/scala/com/carto/analyticstoolbox/modules/accessors/ST_X.scala
@@ -16,13 +16,15 @@
 
 package com.carto.analyticstoolbox.modules.accessors
 
-import com.carto.analyticstoolbox.modules._
 import com.azavea.hiveless.HUDF
-import org.locationtech.geomesa.spark.jts.udf.GeometricAccessorFunctions
-import org.locationtech.jts.geom.Geometry
+import com.carto.analyticstoolbox.modules._
+import org.locationtech.jts.geom.{Geometry, Point}
 
-import java.lang
+import java.{lang => jl}
 
-class ST_X extends HUDF[Geometry, lang.Float] {
-  def function: Geometry => lang.Float = GeometricAccessorFunctions.ST_X
+class ST_X extends HUDF[Geometry, jl.Double] {
+  def function: Geometry => jl.Double = {
+    case geom: Point => geom.getX
+    case _           => null
+  }
 }

--- a/clouds/databricks/libraries/scala/core/src/main/scala/com/carto/analyticstoolbox/modules/accessors/ST_Y.scala
+++ b/clouds/databricks/libraries/scala/core/src/main/scala/com/carto/analyticstoolbox/modules/accessors/ST_Y.scala
@@ -16,13 +16,15 @@
 
 package com.carto.analyticstoolbox.modules.accessors
 
-import com.carto.analyticstoolbox.modules._
 import com.azavea.hiveless.HUDF
-import org.locationtech.geomesa.spark.jts.udf.GeometricAccessorFunctions
-import org.locationtech.jts.geom.Geometry
+import com.carto.analyticstoolbox.modules._
+import org.locationtech.jts.geom.{Geometry, Point}
 
 import java.{lang => jl}
 
-class ST_Y extends HUDF[Geometry, jl.Float] {
-  def function: Geometry => jl.Float = GeometricAccessorFunctions.ST_Y
+class ST_Y extends HUDF[Geometry, jl.Double] {
+  def function: Geometry => jl.Double = {
+    case geom: Point => geom.getY
+    case _           => null
+  }
 }

--- a/clouds/databricks/libraries/scala/core/src/test/scala/com/carto/analyticstoolbox/modules/constructors/STConstructorsSpec.scala
+++ b/clouds/databricks/libraries/scala/core/src/test/scala/com/carto/analyticstoolbox/modules/constructors/STConstructorsSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.carto.analyticstoolbox.modules.constructors
+
+import com.carto.analyticstoolbox.{HiveTestEnvironment, TestTables}
+import org.apache.spark.sql.Row
+import org.scalatest.funspec.AnyFunSpec
+
+class STConstructorsSpec extends AnyFunSpec with HiveTestEnvironment with TestTables {
+  describe("ST constructors functions spec") {
+    it("ST_POINT can be created from the result of ST_X and ST_Y") {
+      val df = ssc.sql(
+        """WITH t AS(
+          |  SELECT ST_POINT(1.5, 2.5) as point
+          |)
+          |SELECT ST_ASTEXT(ST_POINT(ST_X(point), ST_Y(point))) FROM t""".stripMargin
+      )
+      val result: Array[Row] =  df.take(1)
+      result.head.get(0) shouldEqual "POINT (1.5 2.5)"
+    }
+  }
+}

--- a/clouds/databricks/libraries/scala/core/src/test/scala/com/carto/analyticstoolbox/modules/constructors/ST_MakePointTest.scala
+++ b/clouds/databricks/libraries/scala/core/src/test/scala/com/carto/analyticstoolbox/modules/constructors/ST_MakePointTest.scala
@@ -1,0 +1,14 @@
+package com.carto.analyticstoolbox.modules.constructors
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class ST_MakePointTest extends AnyFunSpec {
+  describe("ST_MakePoint") {
+    it("Should create a point with coordinates correctly") {
+      val point = new ST_MakePoint().function(2, 4)
+      point.getX shouldEqual 2
+      point.getY shouldEqual 4
+    }
+  }
+}

--- a/clouds/databricks/modules/doc/accessors/ST_X.md
+++ b/clouds/databricks/modules/doc/accessors/ST_X.md
@@ -12,7 +12,7 @@ If _geom_ is a `Point`, return the X coordinate of that point.
 
 **Return type**
 
-`Float`
+`Double`
 
 **Example**
 

--- a/clouds/databricks/modules/doc/accessors/ST_Y.md
+++ b/clouds/databricks/modules/doc/accessors/ST_Y.md
@@ -12,7 +12,7 @@ If _geom_ is a `Point`, return the Y coordinate of that point.
 
 **Return type**
 
-`Float`
+`Double`
 
 **Example**
 


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/257910/databricks-at-beta-release-the-st-x-y-function-returns-a-float-instead-of-a-double-type

Detected a bug where the result of the functions ST_X and ST_Y cannot be used as arguments of the function ST_POINT without casting it to DOUBLE.

To fix that, the type returned by those functions is changed to Double

## Type of change

#### Changed
- Change type returned by ST_X and ST_Y to Double

# Acceptance

`cd clouds/databricks`
`make deploy`
`make test`

Run the query that was not working in a databricks notebook
```
WITH t AS(
  SELECT ST_X(geom) AS long, ST_Y(geom) AS lat FROM carto_dev_data.points_100k limit 100
)
SELECT ST_POINT(long, lat) FROM t
```
![image](https://user-images.githubusercontent.com/91467822/191439026-3536d6d8-2a78-4038-a054-48f93af95e75.png)

