### PR TITLE
Fix bug with shares deployment in Snowflake

### DIFF
--- a/clouds/snowflake/common/build_share.js
+++ b/clouds/snowflake/common/build_share.js
@@ -109,7 +109,7 @@ for (const functionMatch of functionMatches) {
     let functArgs = functionMatch[0].replace(/[\p{Diacritic}]/gu, '').matchAll(new RegExp('(?<=\\()(.*)(?=\\))','g')).next().value;
     if (functArgs)
     {
-        functArgs = functArgs[0];
+        functArgs = functArgs[0].replace(/^\s+|\s+$|\s+(?=\s)/g, '');
     }
     else
     {


### PR DESCRIPTION
# Description

The bug was caused by some files being linted. The arguments add multiple spaced in between due to line jumps and they were not introduced correctly. I added a regexp replacement to replace multiple spaces by one and remove starting and ending spaces. 

## Type of change

- Fix

# Acceptance

1. Navigate to snowflake/modules/.
2. `make deploy-share`.
3. Check that the share contains all the AT core functions running `show grants to share.<SF_PREFIX>ANALYTICS_TOOLBOX;` in the snowflake console.
