### PR TITLE
docs: add H3 INT/STRING functions reference in BigQuery, Snowflake

### DIFF
--- a/clouds/bigquery/modules/doc/h3/H3_INT_TOSTRING.md
+++ b/clouds/bigquery/modules/doc/h3/H3_INT_TOSTRING.md
@@ -1,7 +1,7 @@
 ### H3_INT_TOSTRING
 
 {{% bannerNote type="code" %}}
-carto.H3_INT_TO_STRING(index)
+carto.H3_INT_TOSTRING(index)
 {{%/ bannerNote %}}
 
 **Description**
@@ -19,6 +19,6 @@ Converts the integer representation of the H3 index to the string representation
 {{%/ customSelector %}}
 
 ```sql
-SELECT `carto-os`.carto.H3_INT_TO_STRING(596645165859340287);
+SELECT `carto-os`.carto.H3_INT_TOSTRING(596645165859340287);
 -- 847b59dffffffff
 ```

--- a/clouds/bigquery/modules/doc/h3/H3_INT_TOSTRING.md
+++ b/clouds/bigquery/modules/doc/h3/H3_INT_TOSTRING.md
@@ -1,0 +1,24 @@
+### H3_INT_TOSTRING
+
+{{% bannerNote type="code" %}}
+carto.H3_INT_TO_STRING(index)
+{{%/ bannerNote %}}
+
+**Description**
+
+Converts the integer representation of the H3 index to the string representation.
+
+* `index`: `INT64` The H3 cell index.
+
+**Return type**
+
+`STRING`
+
+{{% customSelector %}}
+**Example**
+{{%/ customSelector %}}
+
+```sql
+SELECT `carto-os`.carto.H3_INT_TO_STRING(596645165859340287);
+-- 847b59dffffffff
+```

--- a/clouds/bigquery/modules/doc/h3/H3_STRING_TOINT.md
+++ b/clouds/bigquery/modules/doc/h3/H3_STRING_TOINT.md
@@ -1,0 +1,24 @@
+### H3_STRING_TOINT
+
+{{% bannerNote type="code" %}}
+carto.H3_STRING_TOINT(index)
+{{%/ bannerNote %}}
+
+**Description**
+
+Converts the string representation of the H3 index to the integer representation.
+
+* `index`: `STRING` The H3 cell index.
+
+**Return type**
+
+`INT64`
+
+{{% customSelector %}}
+**Example**
+{{%/ customSelector %}}
+
+```sql
+SELECT `carto-os`.carto.H3_STRING_TOINT('847b59dffffffff');
+-- 596645165859340287
+```

--- a/clouds/snowflake/modules/doc/h3/H3_INT_TOSTRING.md
+++ b/clouds/snowflake/modules/doc/h3/H3_INT_TOSTRING.md
@@ -1,0 +1,22 @@
+### H3_INT_TOSTRING
+
+{{% bannerNote type="code" %}}
+carto.H3_INT_TO_STRING(index)
+{{%/ bannerNote %}}
+
+**Description**
+
+Converts the integer representation of the H3 index to the string representation.
+
+* `index`: `INT` The H3 cell index.
+
+**Return type**
+
+`STRING`
+
+**Example**
+
+```sql
+SELECT carto.H3_INT_TO_STRING(596645165859340287);
+-- 847b59dffffffff
+```

--- a/clouds/snowflake/modules/doc/h3/H3_INT_TOSTRING.md
+++ b/clouds/snowflake/modules/doc/h3/H3_INT_TOSTRING.md
@@ -1,7 +1,7 @@
 ### H3_INT_TOSTRING
 
 {{% bannerNote type="code" %}}
-carto.H3_INT_TO_STRING(index)
+carto.H3_INT_TOSTRING(index)
 {{%/ bannerNote %}}
 
 **Description**
@@ -17,6 +17,6 @@ Converts the integer representation of the H3 index to the string representation
 **Example**
 
 ```sql
-SELECT carto.H3_INT_TO_STRING(596645165859340287);
+SELECT carto.H3_INT_TOSTRING(596645165859340287);
 -- 847b59dffffffff
 ```

--- a/clouds/snowflake/modules/doc/h3/H3_STRING_TOINT.md
+++ b/clouds/snowflake/modules/doc/h3/H3_STRING_TOINT.md
@@ -1,0 +1,22 @@
+### H3_STRING_TOINT
+
+{{% bannerNote type="code" %}}
+carto.H3_STRING_TOINT(index)
+{{%/ bannerNote %}}
+
+**Description**
+
+Converts the string representation of the H3 index to the integer representation.
+
+* `index`: `STRING` The H3 cell index.
+
+**Return type**
+
+`INT`
+
+**Example**
+
+```sql
+SELECT carto.H3_STRING_TOINT('847b59dffffffff');
+-- 596645165859340287
+```


### PR DESCRIPTION
# Description

Add SQL documentation reference for:
- BigQuery H3_STRING_TOINT
- BigQuery H3_INT_TOSTRING
- Snowflake H3_STRING_TOINT
- Snowflake H3_INT_TOSTRING

## Type of change

- Documentation
