### PR TITLE
fix(bq,sf): use extended toBeCloseTo in tests

### DIFF
--- a/clouds/bigquery/common/test-extend.js
+++ b/clouds/bigquery/common/test-extend.js
@@ -1,0 +1,29 @@
+const { expect } = require('@jest/globals');
+
+expect.extend({
+    toBeCloseTo (received, expected, precision = 10) {
+
+        function round (obj) {
+            if (!obj) {
+                return obj;
+            }
+            switch (typeof obj) {
+            case 'array':
+                return obj.map(round);
+            case 'object':
+                return Object.keys(obj).reduce((acc, key) => {
+                    acc[key] = round(obj[key]);
+                    return acc;
+                }, {});
+            case 'number':
+                return +obj.toFixed(precision);
+            default:
+                return obj;
+            }
+        }
+
+        expect(round(received)).toEqual(round(expected));
+
+        return { pass: true };
+    }
+});

--- a/clouds/bigquery/modules/Makefile
+++ b/clouds/bigquery/modules/Makefile
@@ -76,7 +76,8 @@ test: check $(NODE_MODULES_DEV)
 		if [ ! -z "$$TESTS" ]; then \
 			GOOGLE_APPLICATION_CREDENTIALS=$(GOOGLE_APPLICATION_CREDENTIALS) \
 			PATH="$(NODE_MODULES_DEV)/.bin/:$(PATH)" \
-			jest --testTimeout=150000 --bail --verbose --slowTestThreshold=20 --maxConcurrency=10 $$TESTS || exit 1; \
+			jest --testTimeout=150000 --bail --verbose --slowTestThreshold=20 --maxConcurrency=10 $$TESTS \
+			     --setupFilesAfterEnv "$(COMMON_DIR)/test-extend.js" || exit 1; \
 			OLD_TEST=$(TEST_DIR)/$$m/old-test; \
 			if [ -d $$OLD_TEST ]; then \
 				echo "Old tests with custon Makefile"; \

--- a/clouds/snowflake/common/test-extend.js
+++ b/clouds/snowflake/common/test-extend.js
@@ -1,0 +1,29 @@
+const { expect } = require('@jest/globals');
+
+expect.extend({
+    toBeCloseTo (received, expected, precision = 10) {
+
+        function round (obj) {
+            if (!obj) {
+                return obj;
+            }
+            switch (typeof obj) {
+            case 'array':
+                return obj.map(round);
+            case 'object':
+                return Object.keys(obj).reduce((acc, key) => {
+                    acc[key] = round(obj[key]);
+                    return acc;
+                }, {});
+            case 'number':
+                return +obj.toFixed(precision);
+            default:
+                return obj;
+            }
+        }
+
+        expect(round(received)).toEqual(round(expected));
+
+        return { pass: true };
+    }
+});

--- a/clouds/snowflake/modules/Makefile
+++ b/clouds/snowflake/modules/Makefile
@@ -80,7 +80,8 @@ test: check $(NODE_MODULES_DEV)
 		TESTS=`$(COMMON_DIR)/list_functions.js $$m --diff="$(diff)" --modules=$(modules) --functions=$(functions)`; \
 		if [ ! -z "$$TESTS" ]; then \
 			PATH="$(NODE_MODULES_DEV)/.bin/:$(PATH)" \
-			jest --testTimeout=40000 --bail --verbose --slowTestThreshold=20 --maxConcurrency=10 $$TESTS || exit 1; \
+			jest --testTimeout=40000 --bail --verbose --slowTestThreshold=20 --maxConcurrency=10 $$TESTS \
+			     --setupFilesAfterEnv "$(COMMON_DIR)/test-extend.js" || exit 1; \
 		fi; \
 	done;
 


### PR DESCRIPTION
Extend `toBeCloseTo` in BigQuery and Snowflake tests for objects