### PR TITLE
doc: remove additional examples from the reference

### DIFF
--- a/clouds/bigquery/modules/doc/clustering/ST_CLUSTERKMEANS.md
+++ b/clouds/bigquery/modules/doc/clustering/ST_CLUSTERKMEANS.md
@@ -24,10 +24,3 @@ SELECT `carto-os`.carto.ST_CLUSTERKMEANS([ST_GEOGPOINT(0, 0), ST_GEOGPOINT(0, 1)
 -- {cluster: 0, geom: POINT(5 0)}
 -- {cluster: 1, geom: POINT(1 0)}
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [New police stations based on Chicago crime location clusters](/analytics-toolbox-bigquery/examples/new-police-stations-based-on-chicago-crime-location-clusters/)
-
-````

--- a/clouds/bigquery/modules/doc/constructors/ST_BEZIERSPLINE.md
+++ b/clouds/bigquery/modules/doc/constructors/ST_BEZIERSPLINE.md
@@ -24,10 +24,3 @@ SELECT `carto-os`.carto.ST_BEZIERSPLINE(
 );
 -- LINESTRING(-76.091308 18.427501, -76.0916216712943 ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Identifying earthquake-prone areas in the state of California](/analytics-toolbox-bigquery/examples/identifying-earthquake-prone-areas-in-the-state-of-california/)
-
-````

--- a/clouds/bigquery/modules/doc/constructors/ST_MAKEENVELOPE.md
+++ b/clouds/bigquery/modules/doc/constructors/ST_MAKEENVELOPE.md
@@ -22,10 +22,3 @@ Creates a rectangular Polygon from the minimum and maximum values for X and Y.
 SELECT `carto-os`.carto.ST_MAKEENVELOPE(0,0,1,1);
 -- POLYGON((1 0, 1 1, 0 1, 0 0, 1 0))
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Identifying earthquake-prone areas in the state of California](/analytics-toolbox-bigquery/examples/identifying-earthquake-prone-areas-in-the-state-of-california/)
-
-````

--- a/clouds/bigquery/modules/doc/constructors/ST_TILEENVELOPE.md
+++ b/clouds/bigquery/modules/doc/constructors/ST_TILEENVELOPE.md
@@ -21,10 +21,3 @@ Returns the boundary polygon of a [tile](https://wiki.openstreetmap.org/wiki/Sli
 SELECT `carto-os`.carto.ST_TILEENVELOPE(10,384,368);
 -- POLYGON((-45 45.089035564831, -45 44.840290651398, -44.82421875 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -44.82421875 45.089035564831, -45 45.089035564831))
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Census areas in the UK within tiles of multiple resolutions](/analytics-toolbox-bigquery/examples/census-areas-in-the-uk-within-tiles-of-multiple-resolutions/)
-
-````

--- a/clouds/bigquery/modules/doc/h3/H3_BOUNDARY.md
+++ b/clouds/bigquery/modules/doc/h3/H3_BOUNDARY.md
@@ -20,10 +20,3 @@ Returns a geography representing the H3 cell. It will return `null` on error (in
 SELECT `carto-os`.carto.H3_BOUNDARY('847b59dffffffff');
 -- POLYGON((40.4650636223452 -3.9352772457965, 40.5465406026705 ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [An H3 grid of Starbucks locations and simple cannibalization analysis](/analytics-toolbox-bigquery/examples/an-h3-grid-of-starbucks-locations-and-simple-cannibalization-analysis/)
-
-````

--- a/clouds/bigquery/modules/doc/h3/H3_DISTANCE.md
+++ b/clouds/bigquery/modules/doc/h3/H3_DISTANCE.md
@@ -28,10 +28,3 @@ SELECT `carto-os`.carto.H3_DISTANCE('847b591ffffffff', '847b59bffffffff');
 If you want the distance in meters use [ST_DISTANCE](https://cloud.google.com/bigquery/docs/reference/standard-sql/geography_functions#st_distance) between the cells ([H3_BOUNDARY](#h3_boundary)) or their centroid.
 
 ````
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Opening a new Pizza Hut location in Honolulu](/analytics-toolbox-bigquery/examples/opening-a-new-pizza-hut-location-in-honolulu/)
-
-````

--- a/clouds/bigquery/modules/doc/h3/H3_FROMGEOGPOINT.md
+++ b/clouds/bigquery/modules/doc/h3/H3_FROMGEOGPOINT.md
@@ -28,13 +28,3 @@ SELECT `carto-os`.carto.H3_FROMGEOGPOINT(ST_GEOGPOINT(40.4168, -3.7038), 4);
 If you want the cells covered by a POLYGON see [H3_POLYFILL](#h3_polyfill).
 
 ````
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [An H3 grid of Starbucks locations and simple cannibalization analysis](/analytics-toolbox-bigquery/examples/an-h3-grid-of-starbucks-locations-and-simple-cannibalization-analysis/)
-* [Opening a new Pizza Hut location in Honolulu](/analytics-toolbox-bigquery/examples/opening-a-new-pizza-hut-location-in-honolulu/)
-* [Computing the spatial autocorrelation of POIs locations in Berlin](/analytics-toolbox-bigquery/examples/computing-the-spatial-autocorrelation-of-pois-locations-in-berlin/)
-* [Identifying amenity hotspots in Stockholm](/analytics-toolbox-bigquery/examples/amenity-hotspots-in-stockholm/)
-
-````

--- a/clouds/bigquery/modules/doc/h3/H3_KRING.md
+++ b/clouds/bigquery/modules/doc/h3/H3_KRING.md
@@ -27,10 +27,3 @@ SELECT `carto-os`.carto.H3_KRING('837b59fffffffff', 1);
 -- 837b4afffffffff
 -- 837b5dfffffffff
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [An H3 grid of Starbucks locations and simple cannibalization analysis](/analytics-toolbox-bigquery/examples/an-h3-grid-of-starbucks-locations-and-simple-cannibalization-analysis/)
-
-````

--- a/clouds/bigquery/modules/doc/h3/H3_POLYFILL.md
+++ b/clouds/bigquery/modules/doc/h3/H3_POLYFILL.md
@@ -33,10 +33,3 @@ SELECT `carto-os`.carto.H3_POLYFILL(
 -- 843ece5ffffffff
 -- ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Opening a new Pizza Hut location in Honolulu](/analytics-toolbox-bigquery/examples/opening-a-new-pizza-hut-location-in-honolulu/)
-
-````

--- a/clouds/bigquery/modules/doc/processing/ST_DELAUNAYLINES.md
+++ b/clouds/bigquery/modules/doc/processing/ST_DELAUNAYLINES.md
@@ -54,10 +54,3 @@ SELECT `carto-os`.carto.ST_DELAUNAYLINES(
 --   LINESTRING(4.18293 43.63475, 4.183 43.63471, 4.18295 43.63479, 4.18293 43.63475)
 -- ]
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [A NYC subway connection graph using Delaunay triangulation](/analytics-toolbox-bigquery/examples/a-nyc-subway-connection-graph-using-delaunay-triangulation/)
-
-````

--- a/clouds/bigquery/modules/doc/processing/ST_POLYGONIZE.md
+++ b/clouds/bigquery/modules/doc/processing/ST_POLYGONIZE.md
@@ -26,10 +26,3 @@ SELECT `carto-os`.carto.ST_POLYGONIZE(
 -- POLYGON((-74.5366825512491 43.6889777784079, -70.7632814028801 42.9679602005825, -70.2005131676838 43.8455720129728, -74.5366825512491 43.6889777784079))
 -- POLYGON((-73.9704330709753 35.3953164724094, -72.514071762468 36.5823995124737, -73.3262122666779 41.2706174323278, -73.9704330709753 35.3953164724094))
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Identifying earthquake-prone areas in the state of California](/analytics-toolbox-bigquery/examples/identifying-earthquake-prone-areas-in-the-state-of-california/)
-
-````

--- a/clouds/bigquery/modules/doc/processing/ST_VORONOIPOLYGONS.md
+++ b/clouds/bigquery/modules/doc/processing/ST_VORONOIPOLYGONS.md
@@ -49,10 +49,3 @@ SELECT `carto-os`.carto.ST_VORONOIPOLYGONS(
 --   POLYGON((4.182 43.634, 4.183 43.634, 4.183 43.634765625, 4.182 43.634140625, 4.182 43.634))
 -- ]
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Analyzing weather stations coverage using a Voronoi diagram](/analytics-toolbox-bigquery/examples/analyzing-weather-stations-coverage-using-a-voronoi-diagram/)
-
-````

--- a/clouds/bigquery/modules/doc/transformations/ST_BUFFER.md
+++ b/clouds/bigquery/modules/doc/transformations/ST_BUFFER.md
@@ -28,12 +28,3 @@ SELECT `carto-os`.carto.ST_BUFFER(
 );
 -- POLYGON((-73.9881354374691 40.7127993926494 ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Bikeshare stations within a San Francisco buffer](/analytics-toolbox-bigquery/examples/bikeshare-stations-within-a-san-francisco-buffer/)
-* [Store cannibalization: quantifying the effect of opening new stores on your existing network](/analytics-toolbox-bigquery/examples/store-cannibalization/)
-* [Opening a new Pizza Hut location in Honolulu](/analytics-toolbox-bigquery/examples/opening-a-new-pizza-hut-location-in-honolulu/)
-
-````

--- a/clouds/bigquery/modules/doc/transformations/ST_CENTERMEAN.md
+++ b/clouds/bigquery/modules/doc/transformations/ST_CENTERMEAN.md
@@ -22,10 +22,3 @@ SELECT `carto-os`.carto.ST_CENTERMEAN(
 );
 -- POINT(25.3890912155939 29.7916831655627)
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [New police stations based on Chicago crime location clusters](/analytics-toolbox-bigquery/examples/new-police-stations-based-on-chicago-crime-location-clusters/)
-
-````

--- a/clouds/bigquery/modules/doc/transformations/ST_GREATCIRCLE.md
+++ b/clouds/bigquery/modules/doc/transformations/ST_GREATCIRCLE.md
@@ -22,10 +22,3 @@ Calculate great circle routes as LineString or MultiLineString. If the start and
 SELECT `carto-os`.carto.ST_GREATCIRCLE(ST_GEOGPOINT(-3.70325,40.4167), ST_GEOGPOINT(-73.9385,40.6643), 20);
 -- LINESTRING(-3.70325 40.4167 ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Computing US airport connections and route interpolations](/analytics-toolbox-bigquery/examples/computing-us-airport-connections-and-route-interpolations/)
-
-````

--- a/clouds/bigquery/modules/doc/transformations/ST_LINE_INTERPOLATE_POINT.md
+++ b/clouds/bigquery/modules/doc/transformations/ST_LINE_INTERPOLATE_POINT.md
@@ -22,10 +22,3 @@ Takes a LineString and returns a Point at a specified distance along the line.
 SELECT `carto-os`.carto.ST_LINE_INTERPOLATE_POINT(ST_GEOGFROMTEXT("LINESTRING (-76.091308 18.427501,-76.695556 18.729501,-76.552734 19.40443,-74.61914 19.134789,-73.652343 20.07657,-73.157958 20.210656)"), 250, 'miles');
 -- POINT(-74.297592068938 19.4498107103156)
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Computing US airport connections and route interpolations](/analytics-toolbox-bigquery/examples/computing-us-airport-connections-and-route-interpolations/)
-
-````

--- a/clouds/snowflake/modules/doc/accessors/ST_ENVELOPE_ARR.md
+++ b/clouds/snowflake/modules/doc/accessors/ST_ENVELOPE_ARR.md
@@ -26,10 +26,3 @@ SELECT carto.ST_ENVELOPE_ARR(
 );
 -- { "coordinates": [ [ [ -75.833, 39.125 ], [ -75.221, 39.125 ], [ -75.221, 39.984 ], ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Analyzing store location coverage using a Voronoi diagram](/analytics-toolbox-snowflake/examples/analyzing-store-location-coverage-using-a-voronoi-diagram/)
-
-````

--- a/clouds/snowflake/modules/doc/clustering/ST_CLUSTERKMEANS.md
+++ b/clouds/snowflake/modules/doc/clustering/ST_CLUSTERKMEANS.md
@@ -32,10 +32,3 @@ SELECT carto.ST_CLUSTERKMEANS(ARRAY_CONSTRUCT(ST_ASGEOJSON(ST_POINT(0, 0))::STRI
 -- {"cluster": 0, "geom": "{\"coordinates\":[5,0],\"type\":\"Point\"}"}
 -- {"cluster": 1, "geom": "{\"coordinates\":[1,0],\"type\":\"Point\"}"}
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [New supplier offices based on store locations clusters](/analytics-toolbox-snowflake/examples/new-supplier-offices-based-on-store-locations-clusters/)
-
-````

--- a/clouds/snowflake/modules/doc/constructors/ST_MAKEELLIPSE.md
+++ b/clouds/snowflake/modules/doc/constructors/ST_MAKEELLIPSE.md
@@ -40,10 +40,3 @@ SELECT carto.ST_MAKEELLIPSE(ST_Point(-73.9385,40.6643), 5, 3, -30, 'miles');
 SELECT carto.ST_MAKEELLIPSE(ST_Point(-73.9385,40.6643), 5, 3, -30, 'miles', 80);
 -- { "coordinates": [ [ [ -73.85585757866869, 40.700482895785946 ], [ -73.86194538052666, 40.70635901954343 ], ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Enrichment of catchment areas for store characterization](/analytics-toolbox-snowflake/examples/enrichment-of-catchment-areas-for-store-characterization/)
-
-````

--- a/clouds/snowflake/modules/doc/measurements/ST_MINKOWSKIDISTANCE.md
+++ b/clouds/snowflake/modules/doc/measurements/ST_MINKOWSKIDISTANCE.md
@@ -37,10 +37,3 @@ SELECT carto.ST_MINKOWSKIDISTANCE(
 );
 -- [ [ 0, 3.333333333333333e-01 ], [ 3.333333333333333e-01, 0 ] ]
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Minkowski distance to perform cannibalization analysis](/analytics-toolbox-snowflake/examples/minkowski-distance-to-perform-cannibalization-analysis/)
-
-````

--- a/clouds/snowflake/modules/doc/processing/ST_VORONOIPOLYGONS.md
+++ b/clouds/snowflake/modules/doc/processing/ST_VORONOIPOLYGONS.md
@@ -66,10 +66,3 @@ SELECT carto.ST_VORONOIPOLYGONS(
 --   "{\"type\":\"Polygon\",\"coordinates\":[[[4.182,43.63414062499997],[4.183,43.634765625],[4.183,43.634],[4.182,43.634],[4.-- 182,43.63414062499997]]]}"
 -- ]
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Analyzing store location coverage using a Voronoi diagram](/analytics-toolbox-snowflake/examples/analyzing-store-location-coverage-using-a-voronoi-diagram/)
-
-````

--- a/clouds/snowflake/modules/doc/transformations/ST_CENTEROFMASS.md
+++ b/clouds/snowflake/modules/doc/transformations/ST_CENTEROFMASS.md
@@ -20,10 +20,3 @@ Takes any Feature or a FeatureCollection and returns its center of mass (also kn
 SELECT carto.ST_CENTEROFMASS(TO_GEOGRAPHY('POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))'));
 -- { "coordinates": [ 25.454545454545453, 26.96969696969697 ], "type": "Point" }
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Computing US airport connections and route interpolations](/analytics-toolbox-snowflake/examples/computing-us-airport-connections-and-route-interpolations/)
-
-````

--- a/clouds/snowflake/modules/doc/transformations/ST_GREATCIRCLE.md
+++ b/clouds/snowflake/modules/doc/transformations/ST_GREATCIRCLE.md
@@ -27,10 +27,3 @@ SELECT carto.ST_GREATCIRCLE(ST_POINT(-3.70325,40.4167), ST_POINT(-73.9385,40.664
 SELECT carto.ST_GREATCIRCLE(ST_POINT(-3.70325,40.4167), ST_POINT(-73.9385,40.6643), 20);
 -- { "coordinates": [ [ -3.7032499999999993, 40.4167 ], ...
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Computing US airport connections and route interpolations](/analytics-toolbox-snowflake/examples/computing-us-airport-connections-and-route-interpolations/)
-
-````

--- a/clouds/snowflake/modules/doc/transformations/ST_LINE_INTERPOLATE_POINT.md
+++ b/clouds/snowflake/modules/doc/transformations/ST_LINE_INTERPOLATE_POINT.md
@@ -27,10 +27,3 @@ SELECT carto.ST_LINE_INTERPOLATE_POINT(TO_GEOGRAPHY('LINESTRING (-76.091308 18.4
 SELECT carto.ST_LINE_INTERPOLATE_POINT(TO_GEOGRAPHY('LINESTRING (-76.091308 18.427501,-76.695556 18.729501,-76.552734 19.40443,-74.61914 19.134789,-73.652343 20.07657,-73.157958 20.210656)'), 250, 'miles');
 -- { "coordinates": [ -74.297592068938, 19.449810710315635 ], "type": "Point" }
 ```
-
-````hint:info
-**ADDITIONAL EXAMPLES**
-
-* [Computing US airport connections and route interpolations](/analytics-toolbox-snowflake/examples/computing-us-airport-connections-and-route-interpolations/)
-
-````


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/284478
- Autolink: [sc-284478]

"Additional examples" section is now generated in the docs from the example's metadata. This way is more flexible in terms of updates in the examples, links, etc.
