### PR TITLE
fix(bq,sf,rs|transformations): great circle crashing for equal origin and end

### DIFF
--- a/clouds/bigquery/modules/sql/transformations/ST_GREATCIRCLE.sql
+++ b/clouds/bigquery/modules/sql/transformations/ST_GREATCIRCLE.sql
@@ -11,7 +11,7 @@ OPTIONS (
     library = ["@@BQ_LIBRARY_BUCKET@@"]
 )
 AS """
-    if (!geojsonStart || !geojsonEnd) {
+    if (!geojsonStart || !geojsonEnd || geojsonEnd === geojsonStart) {
         return null;
     }
     const options = {};

--- a/clouds/bigquery/modules/test/transformations/ST_GREATCIRCLE.test.js
+++ b/clouds/bigquery/modules/test/transformations/ST_GREATCIRCLE.test.js
@@ -20,6 +20,13 @@ test('ST_GREATCIRCLE should return NULL if any NULL mandatory argument', async (
     expect(rows[0].greatcircle2).toEqual(null);
 });
 
+test('ST_GREATCIRCLE should return NULL if start and end are equal', async () => {
+    const query = 'SELECT `@@BQ_DATASET@@.ST_GREATCIRCLE`(ST_GEOGPOINT(0, 0), ST_GEOGPOINT(0, 0), 11) as greatcircle';
+    const rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].greatcircle).toEqual(null);
+});
+
 test('ST_GREATCIRCLE default values should work', async () => {
     const query = `SELECT \`@@BQ_DATASET@@.ST_GREATCIRCLE\`(ST_GEOGPOINT(-3.70325,40.4167), ST_GEOGPOINT(-73.9385,40.6643), 100) as defaultValue,
     \`@@BQ_DATASET@@.ST_GREATCIRCLE\`(ST_GEOGPOINT(-3.70325,40.4167), ST_GEOGPOINT(-73.9385,40.6643), NULL) as nullParam1`;

--- a/clouds/redshift/modules/sql/transformations/ST_GREATCIRCLE.sql
+++ b/clouds/redshift/modules/sql/transformations/ST_GREATCIRCLE.sql
@@ -11,7 +11,7 @@ AS $$
     import geojson
     import json
 
-    if start_point is None or end_point is None or n_points is None:
+    if start_point is None or end_point is None or n_points is None or start_point == end_point:
         return None
 
     _geom = json.loads(start_point)

--- a/clouds/redshift/modules/test/transformations/test_ST_GREATCIRCLE.py
+++ b/clouds/redshift/modules/test/transformations/test_ST_GREATCIRCLE.py
@@ -33,12 +33,15 @@ def test_greatcircle_none():
         @@RS_SCHEMA@@.ST_GREATCIRCLE(
             ST_MakePoint(-5,-5), NULL, 5),
         @@RS_SCHEMA@@.ST_GREATCIRCLE(
-            ST_MakePoint(-5,-5), ST_MakePoint(5,5), NULL) """
+            ST_MakePoint(-5,-5), ST_MakePoint(5,5), NULL),
+        @@RS_SCHEMA@@.ST_GREATCIRCLE(
+            ST_MakePoint(0,0), ST_MakePoint(0,0), NULL) """
     )
 
     assert results[0][0] is None
     assert results[0][1] is None
     assert results[0][2] is None
+    assert results[0][3] is None
 
 
 def test_greatcircle_default():

--- a/clouds/snowflake/modules/sql/transformations/ST_GREATCIRCLE.sql
+++ b/clouds/snowflake/modules/sql/transformations/ST_GREATCIRCLE.sql
@@ -8,7 +8,7 @@ RETURNS STRING
 LANGUAGE JAVASCRIPT
 IMMUTABLE
 AS $$
-    if (!GEOJSONSTART || !GEOJSONEND || NPOINTS == null) {
+    if (!GEOJSONSTART || !GEOJSONEND || NPOINTS == null || GEOJSONSTART === GEOJSONEND) {
         return null;
     }
 

--- a/clouds/snowflake/modules/test/transformations/ST_GREATCIRCLE.test.js
+++ b/clouds/snowflake/modules/test/transformations/ST_GREATCIRCLE.test.js
@@ -22,6 +22,13 @@ test('ST_GREATCIRCLE should return NULL if any NULL mandatory argument', async (
     expect(rows[0].GREATCIRCLE3).toEqual(null);
 });
 
+test('ST_GREATCIRCLE should return NULL if start and end are equal', async () => {
+    const query = 'SELECT ST_GREATCIRCLE(ST_POINT(0, 0), ST_POINT(0, 0), 11) as greatcircle';
+    const rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].GREATCIRCLE).toEqual(null);
+});
+
 test('ST_GREATCIRCLE default values should work', async () => {
     const query = `SELECT ST_GREATCIRCLE(ST_POINT(-3.70325,40.4167), ST_POINT(-73.9385,40.6643), 100) as defaultValue,
     ST_GREATCIRCLE(ST_POINT(-3.70325,40.4167), ST_POINT(-73.9385,40.6643)) as nullParam1`;


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/294737/fix-st-greatcircle-crashing-for-endpoint-startpoint
- Autolink: [294737]

I've fixed this issue in all the providers containing greatcircle. I'm returning a `NULL` but returning any of the points could be a good idea as well. I can do the quick change if needed.

In Rs we were returning a LINESTRING with the same point repeated many times which made no sense.

## Type of change

- Fix

# Acceptance

```
-- BQ
WITH 
origin AS (
SELECT 
id,insee_code_origine,nom_origine,dep_origine,DT_flux_voiture, distance_vol_oiseau_km,
ST_GEOGPOINT(CAST(lon_origine AS float64),CAST(lat_origine AS float64)) AS geom
FROM cartodb-gcp-solutions-eng-team.mbescansa.od_matrix
) ,

destination AS (
SELECT
id,insee_code_destination,nom_destination,DT_flux_voiture,distance_vol_oiseau_km,dep_destination,
ST_GEOGPOINT(CAST(lon_destination AS float64),CAST(lat_destination AS float64)) AS geom
FROM cartodb-gcp-solutions-eng-team.mbescansa.od_matrix
) 

SELECT 
row_number() over() as id,a1.nom_origine,CAST(a1.dep_origine AS string) as dep_origine,a2.nom_destination,CAST(a2.dep_destination AS string) AS dep_destination,a1.DT_flux_voiture,a1.distance_vol_oiseau_km,`cartodb-data-engineering-team`.vdelacruz_carto.ST_GREATCIRCLE(a2.geom,a1.geom,100) as geom, a1.geom AS geom_o, a2.geom AS geom_d
FROM origin a1
JOIN destination a2
ON a1.id = a2.id
WHERE
a1.geom IS NOT NULL
AND a2.geom IS NOT NULL
-- Works
SELECT `cartodb-data-engineering-team`.vdelacruz_carto.ST_GREATCIRCLE(ST_GEOGPOINT(0,0), ST_GEOGPOINT(0,0),100);
-- NULL

-- SF
SELECT CARTO_BACKEND_DATA_TEAM.vdelacruz_carto.ST_GREATCIRCLE(ST_POINT(0,0), ST_POINT(0,0), 100);
-- NULL

-- RS
select vdelacruz_carto.ST_GREATCIRCLE(ST_POINT(0,0),ST_POINT(0,0),100);
-- NULL
```
