### PR TITLE
feat(sf|h3): add h3_resolution

### DIFF
--- a/clouds/snowflake/modules/doc/h3/H3_RESOLUTION.md
+++ b/clouds/snowflake/modules/doc/h3/H3_RESOLUTION.md
@@ -1,0 +1,22 @@
+## H3_RESOLUTION
+
+```sql:signature
+H3_RESOLUTION(index)
+```
+
+**Description**
+
+Returns the H3 cell resolution as an integer. It will return `null` on error (invalid input).
+
+* `index`: `STRING` The H3 cell index.
+
+**Return type**
+
+`INT`
+
+**Example**
+
+```sql
+SELECT carto.H3_RESOLUTION('84390cbffffffff');
+-- 4
+```

--- a/clouds/snowflake/modules/sql/h3/H3_RESOLUTION.sql
+++ b/clouds/snowflake/modules/sql/h3/H3_RESOLUTION.sql
@@ -1,0 +1,15 @@
+----------------------------
+-- Copyright (C) 2023 CARTO
+----------------------------
+
+CREATE OR REPLACE FUNCTION @@SF_SCHEMA@@.H3_RESOLUTION
+(
+    h3 STRING
+)
+RETURNS INT
+AS $$
+    IFF(@@SF_SCHEMA@@.H3_ISVALID(h3),
+        bitshiftright(bitand(@@SF_SCHEMA@@.H3_STRING_TOINT(h3),
+            bitshiftleft(15, 52)), 52),
+        NULL)
+$$;

--- a/clouds/snowflake/modules/test/h3/H3_RESOLUTION.test.js
+++ b/clouds/snowflake/modules/test/h3/H3_RESOLUTION.test.js
@@ -1,0 +1,39 @@
+const { runQuery } = require('../../../common/test-utils');
+
+test('Returns NULL with invalid parameters', async () => {
+    const query = `
+        WITH ids AS
+        (
+            SELECT 1 AS id, NULL as hid UNION ALL
+            SELECT 2 AS id, 'ff283473fffffff' as hid
+        )
+        SELECT
+            id,
+            H3_RESOLUTION(hid) as resolution
+        FROM ids
+        ORDER BY id ASC
+    `;
+
+    const rows = await runQuery(query);
+    expect(rows.length).toEqual(2);
+    expect(rows[0].RESOLUTION).toEqual(null);
+    expect(rows[1].RESOLUTION).toEqual(null);
+});
+
+test('Returns NULL the expected resolution', async () => {
+    const query = `
+        WITH ids AS
+        (
+            SELECT 1 AS id, '85283473fffffff' as hid, 5 AS expected UNION ALL
+            SELECT 2 AS id, '81623ffffffffff' as hid, 1 AS expected
+        )
+        SELECT
+            *,
+            H3_RESOLUTION(hid) as resolution
+        FROM ids
+        WHERE expected != H3_RESOLUTION(hid)
+    `;
+
+    const rows = await runQuery(query);
+    expect(rows.length).toEqual(0);
+});

--- a/clouds/snowflake/modules/test/transformations/ST_CONVEXHULL.test.js
+++ b/clouds/snowflake/modules/test/transformations/ST_CONVEXHULL.test.js
@@ -1,7 +1,7 @@
 const { runQuery } = require('../../../common/test-utils');
 
 test('ST_CONVEXHULL should work', async () => {
-    const query = `SELECT ST_CONVEXHULL(TO_GEOGRAPHY('LINESTRING (-3.5938 41.0403, -4.4006 40.3266, -3.14655 40.1193, -3.7205 40.4743)')) AS CONVEXHULL`;
+    const query = 'SELECT ST_CONVEXHULL(TO_GEOGRAPHY(\'LINESTRING (-3.5938 41.0403, -4.4006 40.3266, -3.14655 40.1193, -3.7205 40.4743)\')) AS CONVEXHULL';
     const rows = await runQuery(query);
     expect(rows.length).toEqual(1);
     expect(JSON.stringify(rows[0].CONVEXHULL)).toEqual('{"coordinates":[[[-3.14655,40.1193],[-4.4006,40.3266],[-3.5938,41.0403],[-3.14655,40.1193]]],"type":"Polygon"}');


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/311338/move-h3-resolution-to-core-in-snowflake
- Autolink: [311338]

## Type of change

- Feature

# Acceptance

```
-- Non valid index
select carto_backend_data_team.vdelacruz_carto.H3_RESOLUTION('ff283473fffffff');
-- NULL
-- Valid index
select carto_backend_data_team.vdelacruz_carto.H3_RESOLUTION('84390cbffffffff');
-- 4
```
