### PR TITLE
Chore/sc 289411/update quadbin fromlonglat formula

### DIFF
--- a/clouds/bigquery/modules/sql/quadbin/QUADBIN_FROMLONGLAT.sql
+++ b/clouds/bigquery/modules/sql/quadbin/QUADBIN_FROMLONGLAT.sql
@@ -12,36 +12,55 @@ AS ((
             ERROR('Invalid resolution; should be between 0 and 26'), (
                 WITH
                 __params AS (
-                    SELECT
+                    select
+                        longitude,
                         resolution AS z,
+                        (1 << resolution) AS __z2,
                         ACOS(-1) AS pi,
                         GREATEST(-85.05, LEAST(85.05, latitude)) AS latitude
+                    from __values
+                ),
+
+                ___sinlat AS (
+                    select SIN(latitude * pi / 180.0) as __sinlat from __params
+                ),
+
+                ___x AS (
+                    SELECT
+                        CAST(
+                            -- floor before cast to avoid up rounding to the next tile
+                            FLOOR(
+                                __z2 * ((longitude / 360.0) + 0.5)
+                            ) AS INT64
+                        ) & (__z2 - 1)  -- bitwise way to calc MOD
+                        AS __x
+                    FROM
+                        __params
                 ),
 
                 __zxy AS (
                     SELECT
                         z,
+                        CASE
+                            WHEN __x < 0 THEN __x + __z2
+                            ELSE __x
+                        END AS x,
                         CAST(
+                            -- floor before cast to avoid up rounding to the next tiLe
                             FLOOR(
-                                (1 << z) * ((longitude / 360.0) + 0.5)
-                            ) AS INT64
-                        ) & ((1 << z) - 1) AS x,
-                        CAST(
-                            FLOOR(
-                                (
-                                    1 << z
-                                ) * (
-                                    0.5 - (
-                                        LN(
-                                            TAN(
-                                                pi / 4.0 + latitude / 2.0 * pi / 180.0
-                                            )
-                                        ) / (2 * pi)
-                                    )
+                                __z2 * (
+                                    0.5 - 0.25 * 
+                                    LN(
+                                        (1 + __sinlat) / (1 - __sinlat)
+                                    ) / pi
                                 )
-                            ) AS INT64
-                        ) & ((1 << z) - 1) AS y
-                    FROM __params
+                            ) AS int64
+                        ) AS y
+                    FROM
+                        __params,
+                        ___sinlat,
+                        ___x
+
                 )
 
                 SELECT `@@BQ_DATASET@@.QUADBIN_FROMZXY`(

--- a/clouds/bigquery/modules/sql/quadbin/QUADBIN_FROMLONGLAT.sql
+++ b/clouds/bigquery/modules/sql/quadbin/QUADBIN_FROMLONGLAT.sql
@@ -12,17 +12,16 @@ AS ((
             ERROR('Invalid resolution; should be between 0 and 26'), (
                 WITH
                 __params AS (
-                    select
+                    SELECT
                         longitude,
                         resolution AS z,
                         (1 << resolution) AS __z2,
                         ACOS(-1) AS pi,
                         GREATEST(-85.05, LEAST(85.05, latitude)) AS latitude
-                    from __values
                 ),
 
                 ___sinlat AS (
-                    select SIN(latitude * pi / 180.0) as __sinlat from __params
+                    SELECT SIN(latitude * pi / 180.0) AS __sinlat FROM __params
                 ),
 
                 ___x AS (
@@ -49,12 +48,12 @@ AS ((
                             -- floor before cast to avoid up rounding to the next tiLe
                             FLOOR(
                                 __z2 * (
-                                    0.5 - 0.25 * 
-                                    LN(
+                                    0.5 - 0.25
+                                    * LN(
                                         (1 + __sinlat) / (1 - __sinlat)
                                     ) / pi
                                 )
-                            ) AS int64
+                            ) AS INT64
                         ) AS y
                     FROM
                         __params,

--- a/clouds/bigquery/modules/test/quadbin/QUADBIN_FROMLONGLAT.test.js
+++ b/clouds/bigquery/modules/test/quadbin/QUADBIN_FROMLONGLAT.test.js
@@ -33,7 +33,7 @@ test('QUADBIN_FROMLONGLAT highest resolution', async () => {
     let query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(-3.71219873428345, 40.413365349070865, 26) AS STRING) AS output';
     let rows = await runQuery(query);
     expect(rows.length).toEqual(1);
-    expect(rows[0].output).toEqual('5306319089810037072');
+    expect(rows[0].output).toEqual('5306319089810035706');
 
     query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(40.413365349070865, -3.71219873428345, 26) AS STRING) AS output';
     rows = await runQuery(query);

--- a/clouds/bigquery/modules/test/quadbin/QUADBIN_FROMLONGLAT.test.js
+++ b/clouds/bigquery/modules/test/quadbin/QUADBIN_FROMLONGLAT.test.js
@@ -28,3 +28,30 @@ test('QUADBIN_FROMLONGLAT should throw an error for resolution overflow', async 
     const query = 'SELECT `@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(40.4168, -3.7038, 27) AS output';
     await expect(runQuery(query)).rejects.toThrow();
 });
+
+test('QUADBIN_FROMLONGLAT highest resolution', async () => {
+    let query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(-3.71219873428345, 40.413365349070865, 26) AS STRING) AS output';
+    let rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5306319089810037072');
+
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(40.413365349070865, -3.71219873428345, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5308641755410858449');
+
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, 3.552713678800501e-15, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5308618060762972160');
+
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, -3.552713678800501e-15, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5308618060762972160');
+
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(-89.71219873428345, -84.413365349070865, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5308521992464067502');
+});

--- a/clouds/bigquery/modules/test/quadbin/QUADBIN_FROMLONGLAT.test.js
+++ b/clouds/bigquery/modules/test/quadbin/QUADBIN_FROMLONGLAT.test.js
@@ -54,4 +54,31 @@ test('QUADBIN_FROMLONGLAT highest resolution', async () => {
     rows = await runQuery(query);
     expect(rows.length).toEqual(1);
     expect(rows[0].output).toEqual('5308521992464067502');
+
+    // set of call giving the same result with slightly different lat
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, 5.3644180297851546e-06, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5307116860887181994');
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, 5.364418029785155e-06, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5307116860887181994');
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, 5.364418029785156e-06, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5307116860887181994');
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, 5.364418029785157e-06, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5307116860887181994');
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, 5.364418029785158e-06, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5307116860887181994');
+    query = 'SELECT CAST(`@@BQ_DATASET@@.QUADBIN_FROMLONGLAT`(0.0, 5.364418029785156e-06, 26) AS STRING) AS output';
+    rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].output).toEqual('5307116860887181994');
+    
 });

--- a/clouds/postgres/README.md
+++ b/clouds/postgres/README.md
@@ -11,6 +11,20 @@ Make sure you have installed the following tools:
 - `jq`: <https://stedolan.github.io/jq/> (v1.6)
 - `virtualenv`: <https://virtualenv.pypa.io/en/latest/> (v20.11)
 
+### Python version issuse with numpy
+
+`make build-modules` will fail in case of `Python3.10.x` due to lack of `numpy` package compatible with this python version.
+Unfortunally Ubuntu 20.4 LTS install Python 3.10.6 by default
+To solve the issue Install a lower version e.g. under ubuntu:
+```
+apt install software-properties-common
+# add repo with python packages
+add-apt-repository ppa:deadsnakes/ppa
+apt install python3.9-full python3.9-distutils
+```
+then modify []./common/Makefile](https://github.com/CartoDB/analytics-toolbox-core/blob/main/clouds/postgres/common/Makefile#L3) python version
+used to setup virtual env
+
 ## Environment variables
 
 The `.env` file contains the variables required to deploy and run the toolbox. Replace each `<template>` with your values.

--- a/clouds/postgres/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
+++ b/clouds/postgres/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
@@ -33,3 +33,55 @@ def test_quadbin_longlat_large_resolution():
     """Throws error for large resolution."""
     with pytest.raises(Exception):
         run_query('SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(40.4168, -3.7038, 27)')
+
+def test_quadbin_longlat_highest_resolution():
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(-3.71219873428345, 40.413365349070865, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5306319089810037072
+
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(40.413365349070865, -3.71219873428345, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308641755410858449
+
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 3.552713678800501e-15, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308618060762972160
+
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, -3.552713678800501e-15, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308618060762972160
+
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(-89.71219873428345, -84.413365349070865, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308521992464067502
+
+    # set of call giving the same result with slightly different lat
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.3644180297851546e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785155e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785156e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785157e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785158e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785156e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994

--- a/clouds/postgres/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
+++ b/clouds/postgres/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
@@ -34,13 +34,20 @@ def test_quadbin_longlat_large_resolution():
     with pytest.raises(Exception):
         run_query('SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(40.4168, -3.7038, 27)')
 
+
 def test_quadbin_longlat_highest_resolution():
-    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(-3.71219873428345, 40.413365349070865, 26)'
+    query = """SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(
+                    -3.71219873428345,
+                    40.413365349070865,
+                    26)"""
     result = run_query(query)
     assert len(result[0]) == 1
-    assert result[0][0] == 5306319089810037072
+    assert result[0][0] == 5306319089810035706
 
-    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(40.413365349070865, -3.71219873428345, 26)'
+    query = """SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(
+                    40.413365349070865,
+                    -3.71219873428345,
+                    26)"""
     result = run_query(query)
     assert len(result[0]) == 1
     assert result[0][0] == 5308641755410858449
@@ -55,7 +62,10 @@ def test_quadbin_longlat_highest_resolution():
     assert len(result[0]) == 1
     assert result[0][0] == 5308618060762972160
 
-    query = 'SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(-89.71219873428345, -84.413365349070865, 26)'
+    query = """SELECT @@PG_SCHEMA@@.QUADBIN_FROMLONGLAT(
+                    -89.71219873428345,
+                    -84.413365349070865,
+                    26)"""
     result = run_query(query)
     assert len(result[0]) == 1
     assert result[0][0] == 5308521992464067502

--- a/clouds/redshift/libraries/python/requirements.txt
+++ b/clouds/redshift/libraries/python/requirements.txt
@@ -1,4 +1,4 @@
-quadbin==0.1.0b1
+quadbin==0.2.0
 geojson==2.5.0
 pygc==1.1.0
 numpy==1.8.2

--- a/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
+++ b/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
@@ -10,17 +10,6 @@ def test_quadbin_fromlonglat():
     assert result[0][0] == 5209574053332910079
 
 
-def test_quadbin_longlat_highest_resolution():
-    """Computes quadbin for longitude latitude at highest resolution.
-    This test is useful to get a reference value to build test and check SQL
-    implementation against this python implementation of quadbin
-    """
-    result = run_query(
-        'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(40.413365349070865, -3.71219873428345, 26)'
-    )
-    assert result[0][0] == 5308641755410858449
-
-
 def test_quadbin_fromlonglat_null():
     result = run_query(
         """
@@ -46,3 +35,86 @@ def test_quadbin_fromlonglat_resolution_overflow_failure():
     error = 'Invalid resolution: should be between 0 and 26'
     with pytest.raises(ProgrammingError, match=error):
         run_query('SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(40.4168, -3.7038, 27)')
+
+
+def test_quadbin_longlat_highest_resolution():
+    """Computes quadbin for longitude latitude at highest resolution.
+
+    This test is useful to get a reference value to build test and check SQL
+    implementation against this python implementation of quadbin
+    """
+    result = run_query(
+        """
+        SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(
+            40.413365349070865,
+            -3.71219873428345,
+            26)
+        """
+    )
+    assert result[0][0] == 5308641755410858449
+
+    query = """
+        SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(
+            -3.71219873428345,
+            40.413365349070865,
+            26)
+    """
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5306319089810035706
+
+    query = """
+        SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(
+            40.413365349070865,
+            -3.71219873428345,
+            26)
+    """
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308641755410858449
+
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 3.552713678800501e-15, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308618060762972160
+
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, -3.552713678800501e-15, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308618060762972160
+
+    query = """
+        SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(
+            -89.71219873428345,
+            -84.413365349070865,
+            26)
+    """
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5308521992464067502
+
+    # set of call giving the same result with slightly different lat
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.3644180297851546e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785155e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785156e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785157e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785158e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994
+    query = 'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(0.0, 5.364418029785156e-06, 26)'
+    result = run_query(query)
+    assert len(result[0]) == 1
+    assert result[0][0] == 5307116860887181994

--- a/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
+++ b/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
@@ -10,6 +10,12 @@ def test_quadbin_fromlonglat():
     assert result[0][0] == 5209574053332910079
 
 
+def test_quadbin_longlat_higher_resolution():
+    """Computes quadbin for longitude latitude."""
+    result = run_query('SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(40.413365349070865, -3.71219873428345, 26)')
+    assert result[0][0] == 5308641755410858449
+
+
 def test_quadbin_fromlonglat_null():
     result = run_query(
         """

--- a/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
+++ b/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
@@ -10,7 +10,7 @@ def test_quadbin_fromlonglat():
     assert result[0][0] == 5209574053332910079
 
 
-def test_quadbin_longlat_higher_resolution():
+def test_quadbin_longlat_highest_resolution():
     """Computes quadbin for longitude latitude at highest resolution.
        This test is useful to get a reference value to build test and check SQL
        implementation against this python implementation of quadbin

--- a/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
+++ b/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
@@ -11,7 +11,10 @@ def test_quadbin_fromlonglat():
 
 
 def test_quadbin_longlat_higher_resolution():
-    """Computes quadbin for longitude latitude."""
+    """Computes quadbin for longitude latitude at highest resolution.
+       This test is useful to get a reference value to build test and check SQL
+       implementation against this python implementation of quadbin
+    """
     result = run_query('SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(40.413365349070865, -3.71219873428345, 26)')
     assert result[0][0] == 5308641755410858449
 

--- a/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
+++ b/clouds/redshift/modules/test/quadbin/test_QUADBIN_FROMLONGLAT.py
@@ -12,10 +12,12 @@ def test_quadbin_fromlonglat():
 
 def test_quadbin_longlat_highest_resolution():
     """Computes quadbin for longitude latitude at highest resolution.
-       This test is useful to get a reference value to build test and check SQL
-       implementation against this python implementation of quadbin
+    This test is useful to get a reference value to build test and check SQL
+    implementation against this python implementation of quadbin
     """
-    result = run_query('SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(40.413365349070865, -3.71219873428345, 26)')
+    result = run_query(
+        'SELECT @@RS_SCHEMA@@.QUADBIN_FROMLONGLAT(40.413365349070865, -3.71219873428345, 26)'
+    )
     assert result[0][0] == 5308641755410858449
 
 


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/289411
- Autolink: [sc-289411]

Ported Python formula in https://github.com/CartoDB/quadbin-py/blob/master/quadbin/utils.py#L119 to SQL.
Refactor applied to BQ and PG.
Original implementation was slightly different and use of other operators.
Maintained in the current SQL implementation the bitwise version of MODULO function.

## Type of change

- Refactor
- Tests

# Acceptance

Please describe how to validate the feature or fix

1. check that any conversion is give the same result as the PY implementation in redshift

# Basic checklist

- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
