### PR TITLE
fix(rs): publish

### DIFF
--- a/.github/workflows/redshift.yml
+++ b/.github/workflows/redshift.yml
@@ -130,6 +130,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON2_VERSION }}
+      - name: Setup python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON3_VERSION }}
       - name: Setup virtualenv
         run: pip install virtualenv==${{ env.VIRTUALENV_VERSION }}
       - name: Auth google


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/320945/fix-publish-at-core-in-rs
- Autolink: [sc-320945]

Install Python3 to avoid crashes when installing virtualenv.

## Type of change

- Fix