### PR TITLE
chore(bq|h3): add intermediate resolution calculation

### DIFF
--- a/clouds/bigquery/modules/sql/h3/H3_POLYFILL.sql
+++ b/clouds/bigquery/modules/sql/h3/H3_POLYFILL.sql
@@ -144,15 +144,9 @@ CREATE OR REPLACE FUNCTION `@@BQ_DATASET@@.__H3_POLYFILL_INIT`
 (geog GEOGRAPHY, resolution INT64)
 RETURNS ARRAY<STRING>
 AS ((
-    IF(geog IS NULL OR resolution IS NULL,
-        NULL,
-        IF(resolution < 0 OR resolution > 15,
-            ERROR('Invalid resolution, should be between 0 and 15'), (
-            SELECT `@@BQ_DATASET@@.__H3_POLYFILL_GEOJSON`(
-                ST_ASGEOJSON(ST_BUFFER(geog, `@@BQ_DATASET@@.__H3_AVG_EDGE_LENGTH`(resolution))),
-                resolution
-            )
-        ))
+    SELECT `@@BQ_DATASET@@.__H3_POLYFILL_GEOJSON`(
+        ST_ASGEOJSON(ST_BUFFER(geog, `@@BQ_DATASET@@.__H3_AVG_EDGE_LENGTH`(resolution))),
+        resolution
     )
 ));
 
@@ -205,16 +199,28 @@ CREATE OR REPLACE FUNCTION `@@BQ_DATASET@@.H3_POLYFILL_MODE`
 (geog GEOGRAPHY, resolution INT64, mode STRING)
 RETURNS ARRAY<STRING>
 AS ((
-    CASE mode
-        WHEN 'intersects' THEN `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_INTERSECTS`(geog, resolution)
-        WHEN 'contains' THEN `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_CONTAINS`(geog, resolution)
-        WHEN 'center' THEN `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_CENTER`(geog, resolution)
-    END
+    IF(geog IS NULL OR resolution IS NULL,
+        NULL,
+        IF(resolution < 0 OR resolution > 15,
+            ERROR('Invalid resolution, should be between 0 and 15'), (
+            CASE mode
+                WHEN 'intersects' THEN `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_INTERSECTS`(geog, resolution)
+                WHEN 'contains' THEN `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_CONTAINS`(geog, resolution)
+                WHEN 'center' THEN `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_CENTER`(geog, resolution)
+            END
+        ))
+    )
 ));
 
 CREATE OR REPLACE FUNCTION `@@BQ_DATASET@@.H3_POLYFILL`
 (geog GEOGRAPHY, resolution INT64)
 RETURNS ARRAY<STRING>
 AS ((
-    SELECT `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_INTERSECTS`(geog, resolution)
+    IF(geog IS NULL OR resolution IS NULL,
+        NULL,
+        IF(resolution < 0 OR resolution > 15,
+            ERROR('Invalid resolution, should be between 0 and 15'), (
+            SELECT `@@BQ_DATASET@@.__H3_POLYFILL_CHILDREN_INTERSECTS`(geog, resolution)
+        ))
+    )
 ));

--- a/clouds/bigquery/modules/sql/h3/H3_POLYFILL.sql
+++ b/clouds/bigquery/modules/sql/h3/H3_POLYFILL.sql
@@ -121,7 +121,7 @@ AS ((
         WHEN area > 307.092 THEN 12
         WHEN area > 43.870 THEN 13
         WHEN area > 6.267 THEN 14
-        ELSE 0
+        ELSE 15
     END
 ));
 
@@ -132,6 +132,13 @@ AS ((
     WITH _bbox AS (SELECT ST_BOUNDINGBOX(geog) AS bbox)
         SELECT `@@BQ_DATASET@@.__H3_POLYFILL_RESOLUTION_BY_AREA`(ST_AREA(`@@BQ_DATASET@@.ST_MAKEENVELOPE`(bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax))) FROM _bbox
 ));
+
+-- CREATE OR REPLACE FUNCTION `@@BQ_DATASET@@.__H3_POLYFILL_INTERMEDIATE_RESOLUTION`
+-- (geog GEOGRAPHY)
+-- RETURNS INT64
+-- AS ((
+--     SELECT `@@BQ_DATASET@@.__H3_POLYFILL_RESOLUTION_BY_AREA`(ST_AREA(`@@BQ_DATASET@@.ST_ENVELOPE`([geog])))
+-- ));
 
 CREATE OR REPLACE FUNCTION `@@BQ_DATASET@@.__H3_POLYFILL_INIT`
 (geog GEOGRAPHY, resolution INT64)


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/STORY_ID
- Autolink: [sc-STORY_ID]

The Area calculation shouldn't be taking long. I did couple of versions and chose the faster.

```
with _bbox as (select ST_BOUNDINGBOX(ST_GEOGFROMTEXT('POLYGON((0 0, 0 .0001, .0001 .0001, .0001 0, 0 0))')) as bbox)
SELECT ST_AREA(`cartodb-data-engineering-team.vdelacruz_carto`.ST_MAKEENVELOPE(bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax)) from _bbox;
-- 123.64350538456635 (112ms)

SELECT ST_AREA(`cartodb-data-engineering-team.vdelacruz_carto`.ST_ENVELOPE([ST_GEOGFROMTEXT('POLYGON((0 0, 0 .0001, .0001 .0001, .0001 0, 0 0))')]));
-- 123.64350525867752 (600 ms)

```

## Type of change

- Refactor
