### PR TITLE
fix(bq,sf,rs,pg,db): fix deploy internal

### DIFF
--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -72,13 +72,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - project: ${{ secrets.BQ_PROJECT_CD }}
-            bucket: ${{ secrets.BQ_BUCKET_CD }}
-            region: ${{ secrets.BQ_REGION_CD }}
+          - project: BQ_PROJECT_CD
+            bucket: BQ_BUCKET_CD
+            region: BQ_REGION_CD
     env:
-      BQ_PROJECT: ${{ matrix.project }}
-      BQ_BUCKET: ${{ matrix.bucket }}
-      BQ_REGION: ${{ matrix.region }}
+      BQ_PROJECT: ${{ secrets[matrix.project] }}
+      BQ_BUCKET: ${{ secrets[matrix.bucket] }}
+      BQ_REGION: ${{ secrets[matrix.region] }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -88,13 +88,13 @@ jobs:
         uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.BQCARTOCD_DEPLOY_CLOUD_EXTENSIONS_SA_BASE64 }}
-          project_id: ${{ env.BQ_PROJECT_CD }}
+          project_id: ${{ env.BQ_PROJECT }}
           create_credentials_file: true
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v0
         with:
             version: ${{ env.GCLOUD_VERSION }}
-            project_id: ${{ env.BQ_PROJECT_CD }}
+            project_id: ${{ env.BQ_PROJECT }}
       - name: Run deploy
         run: |
           cd clouds/bigquery

--- a/.github/workflows/databricks.yml
+++ b/.github/workflows/databricks.yml
@@ -76,13 +76,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - cluster_id: ${{ secrets.DB_CLUSTER_ID_CD }}
-            http_path: ${{ secrets.DB_HTTP_PATH_CD }}
-            host: ${{ secrets.DB_HOST_CD }}
+          - cluster_id: DB_CLUSTER_ID_CD
+            http_path: DB_HTTP_PATH_CD
+            host: DB_HOST_CD
     env:
-      DB_CLUSTER_ID: ${{ matrix.cluster_id }}
-      DB_HTTP_PATH: ${{ matrix.http_path }}
-      DB_HOST: ${{ matrix.host }}
+      DB_CLUSTER_ID: ${{ secrets[matrix.cluster_id] }}
+      DB_HTTP_PATH: ${{ secrets[matrix.http_path] }}
+      DB_HOST: ${{ secrets[matrix.host] }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -62,19 +62,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - host: ${{ secrets.PG_HOST_CD }}
-            database: ${{ secrets.PG_DATABASE_CD }}
-            user: ${{ secrets.PG_USER_CD }}
-            password: ${{ secrets.PG_PASSWORD_CD }}
-          - host: ${{ secrets.PG_HOST_CI }}
-            database: ${{ secrets.PG_DATABASE_CI }}
-            user: ${{ secrets.PG_USER_CI }}
-            password: ${{ secrets.PG_PASSWORD_CI }}
+          - host: PG_HOST_CD
+            database: PG_DATABASE_CD
+            user: PG_USER_CD
+            password: PG_PASSWORD_CD
+          - host: PG_HOST_CI
+            database: PG_DATABASE_CI
+            user: PG_USER_CI
+            password: PG_PASSWORD_CI
     env:
-      PG_HOST: ${{ matrix.host }}
-      PG_DATABASE: ${{ matrix.database }}
-      PG_USER: ${{ matrix.user }}
-      PG_PASSWORD: ${{ matrix.password }}
+      PG_HOST: ${{ secrets[matrix.host] }}
+      PG_DATABASE: ${{ secrets[matrix.database] }}
+      PG_USER: ${{ secrets[matrix.user] }}
+      PG_PASSWORD: ${{ secrets[matrix.password] }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/redshift.yml
+++ b/.github/workflows/redshift.yml
@@ -76,28 +76,31 @@ jobs:
     strategy:
       matrix:
         include:
-          - host: ${{ secrets.RS_HOST_CD }}
-            database: ${{ secrets.RS_DATABASE_CD }}
-            user: ${{ secrets.RS_USER_CD }}
-            password: ${{ secrets.RS_PASSWORD_CD }}
-            bucket: ${{ secrets.RS_BUCKET_CD }}
-            aws_access_key_id: ${{ secrets.RS_AWS_ACCESS_KEY_ID_CD }}
-            aws_secret_access_key: ${{ secrets.RS_AWS_SECRET_ACCESS_KEY_CD }}
-          - host: ${{ secrets.RS_HOST_CI }}
-            database: ${{ secrets.RS_DATABASE_CI }}
-            user: ${{ secrets.RS_USER_CI }}
-            password: ${{ secrets.RS_PASSWORD_CI }}
-            bucket: ${{ secrets.RS_BUCKET_CI }}
-            aws_access_key_id: ${{ secrets.RS_AWS_ACCESS_KEY_ID_CI }}
-            aws_secret_access_key: ${{ secrets.RS_AWS_SECRET_ACCESS_KEY_CI }}
+          - host: RS_HOST_CD
+            database: RS_DATABASE_CD
+            user: RS_USER_CD
+            password: RS_PASSWORD_CD
+            bucket: RS_BUCKET_CD
+            region: RS_REGION_CD
+            aws_access_key_id: RS_AWS_ACCESS_KEY_ID_CD
+            aws_secret_access_key: RS_AWS_SECRET_ACCESS_KEY_CD
+          - host: RS_HOST_CI
+            database: RS_DATABASE_CI
+            user: RS_USER_CI
+            password: RS_PASSWORD_CI
+            bucket: RS_BUCKET_CI
+            region: RS_REGION_CI
+            aws_access_key_id: RS_AWS_ACCESS_KEY_ID_CI
+            aws_secret_access_key: RS_AWS_SECRET_ACCESS_KEY_CI
     env:
-      RS_HOST: ${{ matrix.host }}
-      RS_DATABASE: ${{ matrix.database }}
-      RS_USER: ${{ matrix.user }}
-      RS_PASSWORD: ${{ matrix.password }}
-      RS_BUCKET: ${{ matrix.bucket }}
-      AWS_ACCESS_KEY_ID: ${{ matrix.aws_access_key_id }}
-      AWS_SECRET_ACCESS_KEY: ${{ matrix.aws_secret_access_key }}
+      RS_HOST: ${{ secrets[matrix.host] }}
+      RS_DATABASE: ${{ secrets[matrix.database] }}
+      RS_USER: ${{ secrets[matrix.user] }}
+      RS_PASSWORD: ${{ secrets[matrix.password] }}
+      RS_BUCKET: ${{ secrets[matrix.bucket] }}
+      RS_REGION: ${{ secrets[matrix.region] }}
+      AWS_ACCESS_KEY_ID: ${{ secrets[matrix.aws_access_key_id] }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets[matrix.aws_secret_access_key] }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -120,9 +123,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.RS_AWS_ACCESS_KEY_ID_CD }}
-          aws-secret-access-key: ${{ secrets.RS_AWS_SECRET_ACCESS_KEY_CD }}
-          aws-region: ${{ secrets.RS_REGION_CD }}
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.RS_REGION }}
       - name: Run deploy
         run: |
           cd clouds/redshift

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -63,17 +63,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - account: ${{ secrets.SF_ACCOUNT_CD }}
-            database: ${{ secrets.SF_DATABASE_CD }}
-            user: ${{ secrets.SF_USER_CD }}
-            password: ${{ secrets.SF_PASSWORD_CD }}
-            role: ${{ secrets.SF_ROLE_CD }}
+          - account: SF_ACCOUNT_CD
+            database: SF_DATABASE_CD
+            user: SF_USER_CD
+            password: SF_PASSWORD_CD
+            role: SF_ROLE_CD
     env:
-      SF_ACCOUNT: ${{ matrix.account }}
-      SF_DATABASE: ${{ matrix.database }}
-      SF_USER: ${{ matrix.user }}
-      SF_PASSWORD: ${{ matrix.password }}
-      SF_ROLE: ${{ matrix.role }}
+      SF_ACCOUNT: ${{ secrets[matrix.account] }}
+      SF_DATABASE: ${{ secrets[matrix.database] }}
+      SF_USER: ${{ secrets[matrix.user] }}
+      SF_PASSWORD: ${{ secrets[matrix.password] }}
+      SF_ROLE: ${{ secrets[matrix.role] }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/328359/at-deploy-internal-for-ci-in-all-clouds
- Autolink: [sc-328359]

Matrixes were not compatible with secrets so we changed the approach. Now we store secrets ids in the matrix.

## Type of change

- Fix
