### PR TITLE
fix(bq,sf): avoid linting node_modules

### DIFF
--- a/clouds/bigquery/Makefile
+++ b/clouds/bigquery/Makefile
@@ -38,8 +38,8 @@ lint-common: venv3 $(NODE_MODULES_DEV)
 	PATH="$(NODE_MODULES_DEV)/.bin/:$(PATH)" \
 	markdownlint -f '*.md' --ignore node_modules --disable MD013 MD024 MD033 MD036 MD040 MD041 MD051 MD045 --
 	echo "- Lint Python files"
-	$(VENV3_BIN)/brunette $(COMMON_DIR) --line-length=88 --single-quotes --quiet
-	$(VENV3_BIN)/flake8 $(COMMON_DIR) --max-line-length=88 --enable-extensions Q0 --ignore=D100,D103,D104,E203
+	$(VENV3_BIN)/brunette $(COMMON_DIR) --exclude node_modules --line-length=88 --single-quotes --quiet
+	$(VENV3_BIN)/flake8 $(COMMON_DIR) --exclude node_modules --max-line-length=88 --enable-extensions Q0 --ignore=D100,D103,D104,E203
 
 build:
 	rm -rf $(BUILD_DIR)

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -38,8 +38,8 @@ lint-common: $(NODE_MODULES_DEV) venv3
 	PATH="$(NODE_MODULES_DEV)/.bin/:$(PATH)" \
 	markdownlint -f '*.md' --ignore node_modules --disable MD013 MD024 MD033 MD036 MD040 MD041 MD051 MD045 --
 	echo "- Lint Python files"
-	$(VENV3_BIN)/brunette $(COMMON_DIR) --line-length=88 --single-quotes --quiet
-	$(VENV3_BIN)/flake8 $(COMMON_DIR) --max-line-length=88 --enable-extensions Q0 --ignore=D100,D103,D104,E203
+	$(VENV3_BIN)/brunette $(COMMON_DIR) --exclude node_modules --line-length=88 --single-quotes --quiet
+	$(VENV3_BIN)/flake8 $(COMMON_DIR) --exclude node_modules --max-line-length=88 --enable-extensions Q0 --ignore=D100,D103,D104,E203
 
 build:
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
# Description

Shortcut

- Autolink: [sc-342684]

It seems that in some cases node_modules could include python files. This code update should exclude those files.

## Type of change

- Fix