### PR TITLE
fix(rs,pg) run_script exit code on error

### DIFF
--- a/clouds/postgres/common/run_script.py
+++ b/clouds/postgres/common/run_script.py
@@ -42,9 +42,11 @@ if __name__ == '__main__':
         except Exception as error:
             error_msg = str(error)
             print(f'ERROR: {error_msg}')
+            exit(1)
     else:
         try:
             run_queries(split(content))
         except Exception as error:
             error_msg = str(error)
             print(f'[{function}] ERROR: {error_msg}')
+            exit(1)

--- a/clouds/redshift/common/run_script.py
+++ b/clouds/redshift/common/run_script.py
@@ -42,3 +42,4 @@ if __name__ == '__main__':
     except ProgrammingError as error:
         error_msg = re.search("'M': '(.*?)',", str(error)).group(1)
         print(f'[{function}] ERROR: {error_msg}')
+        exit(1)


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/357932
- Autolink: [sc-357932]

When run_script failed the exit code was 0, so `make` would continue with the following steps.

## Type of change

- Fix
