### PR TITLE
chore: update dependency bigquery to 7.3.0

### DIFF
--- a/clouds/bigquery/common/package.json
+++ b/clouds/bigquery/common/package.json
@@ -1,7 +1,7 @@
 {
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "@google-cloud/bigquery": "^5.3.0",
+    "@google-cloud/bigquery": "^7.3.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",


### PR DESCRIPTION
# Ticket
https://app.shortcut.com/cartoteam/story/342684/at-deploy-timeout-to-me-regions-and-others

# Tested locally
There's no dependency issue after upgrading `bigquery` from `^5.3.0` to `^7.3.0` (latest) ✅ 
```
~/git/analytics-toolbox-core/clouds/bigquery$ cat .env
# BigQuery
BQ_PREFIX=jarroyo_
BQ_PROJECT=cartodb-data-engineering-team
BQ_BUCKET=gs://bqcartodev
BQ_REGION=us
GOOGLE_APPLICATION_CREDENTIALS=/home/albertoh/.config/gcloud/legacy_credentials/albertoh@cartodb.com/adc.json
BQ_LDS_ENDPOINT=https://lds-func-us-ea1-1942-cmc6qlhtda-ue.a.run.app
BQ_LDS_CONNECTION=cartodb-data-engineering-team.us.jarroyo-test-conn
BQ_API_BASE_URL=https://gcp-us-east1.api.carto.com
BQ_LDS_TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJhIjoiYWNfNTEyYnI2aG4iLCJqdGkiOiI4NTQ5YzFjNiJ9.6A-kvXaZ6tmMUEPwi590mxg3ghyJ6EY9RAMqMPlGImo
BQ_GATEWAY_ENDPOINT=https://us-central1-cartodb-data-engineering-team.cloudfunctions.net/request
BQ_GATEWAY_CONNECTION=cartodb-data-engineering-team.us.jarroyo-test-conn

~/git/analytics-toolbox-core/clouds/bigquery$ make deploy
Building libraries...

/home/albertoh/git/analytics-toolbox-core/clouds/bigquery/libraries/javascript/libs/index.js → build/index.js...
Created bundle index.js: 590.46 kB → 152.05 kB (gzip)
created build/index.js in 12.7s
Deploying libraries...
Copying file:///home/albertoh/git/analytics-toolbox-core/clouds/bigquery/libraries/javascript/build/index.js [Content-Type=application/javascript]...
- [1 files][576.6 KiB/576.6 KiB]                                                
Operation completed over 1 objects/576.6 KiB.                                    
Building modules...
- Build all
Write /home/albertoh/git/analytics-toolbox-core/clouds/bigquery/modules/build/modules.sql
Deploying modules...
```