### PR TITLE
fix(bq|h3): fix broken reference in H3_POLYFILL_TABLE

### DIFF
--- a/clouds/bigquery/modules/sql/h3/H3_POLYFILL_TABLE.sql
+++ b/clouds/bigquery/modules/sql/h3/H3_POLYFILL_TABLE.sql
@@ -29,7 +29,7 @@ AS """
     return 'CREATE TABLE `' + output_table + '` CLUSTER BY (h3) AS\\n' +
         'WITH __input AS (' + input_query + '),\\n' +
         '__cells AS (SELECT h3, i.* FROM __input AS i,\\n' +
-        'UNNEST(`@@BQ_DATASET@@.__H3_POLYFILL_INIT`(geom,`@@BQ_DATASET@@.__H3_POLYFILL_INIT_Z`(geom,' + resolution + '))) AS parent,\\n' +
+        'UNNEST(`@@BQ_DATASET@@.__H3_POLYFILL_INIT_BBOX`(geom,`@@BQ_DATASET@@.__H3_POLYFILL_INIT_Z`(geom,' + resolution + '))) AS parent,\\n' +
         'UNNEST(`@@BQ_DATASET@@.H3_TOCHILDREN`(parent,' + resolution + ')) AS h3)\\n' +
         'SELECT * EXCEPT (geom) FROM __cells\\n' +
         'WHERE ' + containmentFunction + '(geom, `' + cellFunction + '`(h3));'

--- a/clouds/bigquery/modules/test/h3/H3_POLYFILL_TABLE.test.js
+++ b/clouds/bigquery/modules/test/h3/H3_POLYFILL_TABLE.test.js
@@ -2,6 +2,24 @@ const { runQuery } = require('../../../common/test-utils');
 
 const BQ_DATASET = process.env.BQ_DATASET;
 
+test('H3_POLYFILL_TABLE should work', async () => {
+    output_table_name = 'h3_polyfill_table_geom_output'
+    let query = `DROP TABLE IF EXISTS \`@@BQ_DATASET@@.${output_table_name}\`;
+        CALL \`@@BQ_DATASET@@.H3_POLYFILL_TABLE\`(
+        'SELECT ST_GEOGFROMTEXT("POLYGON ((-3.71219873428345 40.413365349070865, -3.7144088745117 40.40965661286395, -3.70659828186035 40.409525904775634, -3.71219873428345 40.413365349070865))") as geom',
+        9, 'center',
+        '@@BQ_DATASET@@.${output_table_name}'
+    )`;
+    await runQuery(query);
+
+    const rows = await runQuery(`SELECT * FROM \`@@BQ_DATASET@@.${output_table_name}\``);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].h3).toEqual('89390cb1b4bffff');
+
+    query = `DROP TABLE IF EXISTS \`@@BQ_DATASET@@.${output_table_name}\``;
+    await runQuery(query);
+});
+
 test('H3_POLYFILL_TABLE should generate the correct query', async () => {
     const query = `SELECT \`@@BQ_DATASET@@.__H3_POLYFILL_QUERY\`(
         'SELECT geom, name, value FROM \`<project>.<dataset>.<table>\`',
@@ -13,7 +31,7 @@ test('H3_POLYFILL_TABLE should generate the correct query', async () => {
     expect(rows[0].output).toEqual(`CREATE TABLE \`<project>.<dataset>.<output_table>\` CLUSTER BY (h3) AS
 WITH __input AS (SELECT geom, name, value FROM \`<project>.<dataset>.<table>\`),
 __cells AS (SELECT h3, i.* FROM __input AS i,
-UNNEST(\`@@BQ_DATASET@@.__H3_POLYFILL_INIT\`(geom,\`@@BQ_DATASET@@.__H3_POLYFILL_INIT_Z\`(geom,12))) AS parent,
+UNNEST(\`@@BQ_DATASET@@.__H3_POLYFILL_INIT_BBOX\`(geom,\`@@BQ_DATASET@@.__H3_POLYFILL_INIT_Z\`(geom,12))) AS parent,
 UNNEST(\`@@BQ_DATASET@@.H3_TOCHILDREN\`(parent,12)) AS h3)
 SELECT * EXCEPT (geom) FROM __cells
 WHERE ST_INTERSECTS(geom, \`@@BQ_DATASET@@.H3_CENTER\`(h3));`.replace(/@@BQ_DATASET@@/g, BQ_DATASET));


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/373790/h3-polyfill-table-in-bq-not-working
- Autolink: [sc-373790]

It seems that we didn't reference an internal function correctly.

## Type of change

- Fix

# Acceptance

```
CALL `cartodb-data-engineering-team`.vdelacruz_carto.H3_POLYFILL_TABLE(
  'SELECT geom FROM `cartodb-data-engineering-team.vdelacruz_carto.newyork_ooh_sample_audience_h3`',
  9, 'center',
  'cartodb-data-engineering-team.vdelacruz_carto.newyork_ooh_sample_audience_h3_out'
);
-- WORKS
```