### PR TITLE
chore(bq,sf,rs,pg): fix naming dedicated deployments for releases

### DIFF
--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -27,15 +27,11 @@ jobs:
       - name: Set BQ_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#release/}
-          echo "BQ_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "BQ_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set BQ_PREFIX for hotfixes
         if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#hotfix/}
-          echo "BQ_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "BQ_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set BQ_PREFIX for regular deploys
         if: |
           !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&

--- a/.github/workflows/postgres-ded.yml
+++ b/.github/workflows/postgres-ded.yml
@@ -26,18 +26,14 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Set PG_PREFIX for releases
+     - name: Set PG_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#release/}
-          echo "PG_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "PG_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set PG_PREFIX for hotfixes
         if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#hotfix/}
-          echo "PG_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "PG_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set PG_PREFIX for regular deploys
         if: |
           !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&

--- a/.github/workflows/redshift-ded.yml
+++ b/.github/workflows/redshift-ded.yml
@@ -33,15 +33,11 @@ jobs:
       - name: Set RS_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#release/}
-          echo "RS_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "RS_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set RS_PREFIX for hotfixes
         if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#hotfix/}
-          echo "RS_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "RS_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set RS_PREFIX for regular deploys
         if: |
           !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&

--- a/.github/workflows/snowflake-ded.yml
+++ b/.github/workflows/snowflake-ded.yml
@@ -28,15 +28,11 @@ jobs:
       - name: Set SF_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#release/}
-          echo "SF_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "SF_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set SF_PREFIX for hotfixes
         if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#hotfix/}
-          echo "SF_PREFIX=dedicated_release_${VERSION}_" >> $GITHUB_ENV
+          echo "SF_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set SF_PREFIX for regular deploys
         if: |
           !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/330620/fix-dedicated-deployments-for-releases-in-atc
- Autolink: [sc-330620]

## Type of change

- Fix

# Acceptance

Will have to test on next releases. But the code is the one that we have in Advanced and it was working fine there.