### PR TITLE
chore(pg): fix typo naming dedicated deployments for releases 

### DIFF
--- a/.github/workflows/postgres-ded.yml
+++ b/.github/workflows/postgres-ded.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-     - name: Set PG_PREFIX for releases
+      - name: Set PG_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
           echo "PG_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/330620/fix-dedicated-deployments-for-releases-in-atc
- Autolink: [sc-330620]

## Type of change

- Fix

# Acceptance

Will have to test on next releases. But the code is the one that we have in Advanced and it was working fine there.