### PR TITLE
chore(bs,sf|constructors): update internal function used by ST_TILEENVELOPE

### DIFF
--- a/.github/workflows/snowflake-ded.yml
+++ b/.github/workflows/snowflake-ded.yml
@@ -5,7 +5,7 @@ on:
     types: [closed, unlabeled, labeled, synchronize]
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 16
 
 jobs:
 

--- a/clouds/bigquery/modules/sql/constructors/ST_TILEENVELOPE.sql
+++ b/clouds/bigquery/modules/sql/constructors/ST_TILEENVELOPE.sql
@@ -6,8 +6,8 @@ CREATE OR REPLACE FUNCTION `@@BQ_DATASET@@.ST_TILEENVELOPE`
 (zoomLevel INT64, xTile INT64, yTile INT64)
 RETURNS GEOGRAPHY
 AS (
-    `@@BQ_DATASET@@.QUADINT_BOUNDARY`(
-        `@@BQ_DATASET@@.QUADINT_FROMZXY`(
+    `@@BQ_DATASET@@.QUADBIN_BOUNDARY`(
+        `@@BQ_DATASET@@.QUADBIN_FROMZXY`(
             zoomlevel, xtile, ytile
         )
     )

--- a/clouds/bigquery/modules/test/constructors/ST_TILEENVELOPE.test.js
+++ b/clouds/bigquery/modules/test/constructors/ST_TILEENVELOPE.test.js
@@ -15,7 +15,9 @@ test('ST_TILEENVELOPE should work', async () => {
 
 test('ST_TILEENVELOPE should fail if any NULL argument', async () => {
     const query = `
-        SELECT \`@@BQ_DATASET@@.ST_TILEENVELOPE\`(10, 384, null)
+        SELECT \`@@BQ_DATASET@@.ST_TILEENVELOPE\`(10, 384, null) AS geog
     `;
-    await expect(runQuery(query)).rejects.toThrow();
+    const rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].geog).toEqual(null);
 });

--- a/clouds/snowflake/modules/test/constructors/ST_TILEENVELOPE.test.js
+++ b/clouds/snowflake/modules/test/constructors/ST_TILEENVELOPE.test.js
@@ -13,9 +13,11 @@ test('ST_TILEENVELOPE should work', async () => {
     expect(JSON.stringify(rows[0].GEOG3)).toEqual('{"coordinates":[[[-44.99998927116395,45.000002199069606],[-44.99998927116395,44.99999461263666],[-45,44.99999461263666],[-45,45.000002199069606],[-44.99998927116395,45.000002199069606]]],"type":"Polygon"}');
 });
 
-test('ST_TILEENVELOPE should fail if any NULL argument', async () => {
+test('ST_TILEENVELOPE should return NULL if any NULL argument', async () => {
     const query = `
-        SELECT ST_TILEENVELOPE(10, 384, null)
+        SELECT ST_TILEENVELOPE(10, 384, null) as geog
     `;
-    await expect(runQuery(query)).rejects.toThrow();
+    const rows = await runQuery(query);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].GEOG).toEqual(null);
 });


### PR DESCRIPTION
# Description

The tests on this PR https://github.com/CartoDB/analytics-toolbox-core/pull/466 are failing due to recent updates in the default values of QUADBIN functions. Snowflake QUADBIN UDFs now return NULL for NULL arguments as it happens in Bigquery and as it was happening in some Quadbin Snowflake UDFs.

After seen the tests failing, I've discovered that in Bigquery we were still using the deprecated QUADINT functions to calculate the tile envelope.

Now ST_TILEENVELOPE returns `NULL` for null arguments. Unless we explicitly want to trigger an error.

## Type of change

- Refactor
