### PR TITLE
chore(sf): add additional tables to native apps

### DIFF
--- a/clouds/snowflake/common/build_native_app_setup_script.js
+++ b/clouds/snowflake/common/build_native_app_setup_script.js
@@ -15,6 +15,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const inputDirs = argv._[0] && argv._[0].split(',');
 const outputDir = argv.output || 'build';
 const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
+const nativeAppDir = argv.native_app_dir || '../native_app';
 const diff = argv.diff || [];
 const nodeps = argv.nodeps;
 let modulesFilter = (argv.modules && argv.modules.split(',')) || [];
@@ -232,8 +233,13 @@ const header = `CREATE OR REPLACE APPLICATION ROLE @@APP_ROLE@@;
 CREATE OR ALTER VERSIONED SCHEMA @@SF_SCHEMA@@;
 GRANT USAGE ON SCHEMA @@SF_SCHEMA@@ TO APPLICATION ROLE @@APP_ROLE@@;\n`;
 
+let additionalTables = '';
+if (argv.production) {
+    additionalTables = fs.readFileSync(path.resolve(nativeAppDir, 'ADDITIONAL_TABLES.sql')).toString() + separator;
+}
+
 const footer = fetchPermissionsGrant (fs.readFileSync(path.resolve(__dirname, 'VERSION.sql')).toString());
-content = header + separator + content + separator + footer;
+content = header + separator + additionalTables + content + separator + footer;
 
 content = apply_replacements(content);
 

--- a/clouds/snowflake/modules/Makefile
+++ b/clouds/snowflake/modules/Makefile
@@ -9,6 +9,7 @@ SQL_DIR ?= $(ROOT_DIR)/sql
 ESLINTRC_DIR ?= $(ROOT_DIR)/../../..
 COMMON_DIR = $(ROOT_DIR)/../common
 LIBS_BUILD_DIR ?= $(ROOT_DIR)/../libraries/javascript/build
+NATIVE_APP_DIR ?= $(ROOT_DIR)/../native_app
 
 MODULES_DIRS ?= $(ROOT_DIR)
 export SF_VERSION_FUNCTION ?= VERSION_CORE
@@ -75,7 +76,7 @@ build-native-app-setup-script: $(NODE_MODULES_DEV)
 	SF_SCHEMA=$(SF_UNQUALIFIED_SCHEMA) APP_ROLE=app_public \
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	$(COMMON_DIR)/build_native_app_setup_script.js $(MODULES_DIRS) \
-		--output=$(BUILD_DIR) --libs_build_dir=$(LIBS_BUILD_DIR) --diff="$(diff)" \
+		--output=$(BUILD_DIR) --libs_build_dir=$(LIBS_BUILD_DIR) --native_app_dir=$(NATIVE_APP_DIR) --diff="$(diff)" \
 		--modules=$(modules) --functions=$(functions) --production=$(production) --nodeps=$(nodeps) --dropfirst=1
 
 deploy: check build


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/377459/publish-analytics-toolbox-native-app-in-snowflake
- Autolink: [sc-377459]

Adding tables requires some changes on the infra. I set it up so only when `production=1` is added the tables are included in the build.

## Type of change

- Refactor
