### PR TITLE
docs(bs,sf,rs|transformations): fix ST_DESTINATION bearing parameter description

### DIFF
--- a/clouds/bigquery/modules/doc/transformations/ST_DESTINATION.md
+++ b/clouds/bigquery/modules/doc/transformations/ST_DESTINATION.md
@@ -10,7 +10,7 @@ Takes a Point and calculates the location of a destination point given a distanc
 
 * `origin`: `GEOGRAPHY` starting point.
 * `distance`: `FLOAT64` distance from the origin point in the units specified.
-* `bearing`: `FLOAT64` counter-clockwise angle from East, ranging from -180 to 180 (e.g. 0 is East, 90 is North, 180 is West, -90 is South).
+* `bearing`: `FLOAT64` ranging from -180 to 180 (e.g. 0 is North, 90 is East, 180 is South, -90 is West).
 * `units`: `STRING`|`NULL` units of length, the supported options are: `miles`, `kilometers`, `degrees` or `radians`. If `NULL`the default value `kilometers` is used.
 
 **Return type**

--- a/clouds/redshift/modules/doc/transformations/ST_DESTINATION.md
+++ b/clouds/redshift/modules/doc/transformations/ST_DESTINATION.md
@@ -10,7 +10,7 @@ Takes a Point and calculates the location of a destination point given a distanc
 
 * `geom`: `GEOMETRY` starting point.
 * `distance`: `FLOAT8` distance from the origin point in the units specified.
-* `bearing`: `FLOAT8` counter-clockwise angle from East, ranging from -180 to 180 (e.g. 0 is East, 90 is North, 180 is West, -90 is South).
+* `bearing`: `FLOAT8` ranging from -180 to 180 (e.g. 0 is North, 90 is East, 180 is South, -90 is West).
 * `units` (optional): `VARCHAR(15)` units of length. The supported options are: `miles`, `kilometers`, `degrees` or `radians`. If `NULL`the default value `kilometers` is used.
 
 **Return type**

--- a/clouds/snowflake/modules/doc/transformations/ST_DESTINATION.md
+++ b/clouds/snowflake/modules/doc/transformations/ST_DESTINATION.md
@@ -10,7 +10,7 @@ Takes a Point and calculates the location of a destination point given a distanc
 
 * `origin`: `GEOGRAPHY` starting point.
 * `distance`: `DOUBLE` distance from the origin point in the units specified.
-* `bearing`: `DOUBLE` counter-clockwise angle from East, ranging from -180 to 180 (e.g. 0 is East, 90 is North, 180 is West, -90 is South).
+* `bearing`: `DOUBLE` ranging from -180 to 180 (e.g. 0 is North, 90 is East, 180 is South, -90 is West).
 * `units` (optional): `STRING` units of length, the supported options are: `miles`, `kilometers`, `degrees` or `radians`. If `NULL`the default value `kilometers` is used.
 
 **Return type**


### PR DESCRIPTION
# Description

Shortcut

As mentioned on this issue: https://github.com/CartoDB/analytics-toolbox-core/issues/474 the doc on ST_DESTINATION does not correspond with the actual implementation. It seems like a bug introduced by us because the extra information is not included in turf docs.

## Type of change

- Documentation

# Acceptance

Just performed the same test described in the ticket.