### PR TITLE
fix(sf): CI and CD not working because of snowflake driver breaking changes

### DIFF
--- a/clouds/snowflake/common/package.json
+++ b/clouds/snowflake/common/package.json
@@ -11,6 +11,6 @@
     "rollup": "^2.47.0",
     "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-terser": "^7.0.2",
-    "snowflake-sdk": "^1.6.6"
+    "snowflake-sdk": "1.9.3"
   }
 }


### PR DESCRIPTION
# Description

Shortcut

It seems that the [latest release](https://docs.snowflake.com/en/release-notes/clients-drivers/nodejs-2024#version-1-10-0-february-27-2024) of the snowflake driver for js is causing the CI and CD to break. For this reason I am fixing the version to the previous one to that `1.9.3`.

```
{"level":"INFO","message":"[5:09:00.151 PM]: Trying to initialize Easy Logging"}
Unable to perform operation because a connection was never established.
{"level":"INFO","message":"[5:09:00.171 PM]: No client config file found in default directories"}
{"level":"INFO","message":"[5:09:00.172 PM]: Easy Logging is disabled as no config has been found"}
{"level":"INFO","message":"[5:09:01.035 PM]: Trying to initialize Easy Logging"}

ERROR: Unable to perform operation because a connection was never established.
```

## Type of change

- Fix