### PR TITLE
fix(bq,sf,rs,pg): drop schemas when dedicateds gets released

### DIFF
--- a/.github/workflows/redshift-ded.yml
+++ b/.github/workflows/redshift-ded.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.event.action == 'synchronize' || github.event.action == 'labeled'
         run: |
           cd clouds/redshift
-          make deploy
+          make deploy dropfirst=1
       - name: Run remove
         id: remove
         if: github.event.action == 'unlabeled' || github.event.action == 'closed'

--- a/.github/workflows/redshift-ded.yml
+++ b/.github/workflows/redshift-ded.yml
@@ -33,6 +33,19 @@ jobs:
         uses: actions/checkout@v2
       - name: Check diff
         uses: technote-space/get-diff-action@v4
+      - name: Set RS_PREFIX for releases
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          echo "RS_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+      - name: Set RS_PREFIX for hotfixes
+        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          echo "RS_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+      - name: Set RS_PREFIX for the rest
+        if: |
+          !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
+          !(startsWith(github.event.pull_request.head.ref, 'release/'))
+        run: echo "RS_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/clouds/bigquery/modules/Makefile
+++ b/clouds/bigquery/modules/Makefile
@@ -34,10 +34,10 @@ include $(COMMON_DIR)/Makefile
 
 .SILENT:
 
-.PHONY: help lint build build-share deploy deploy-share test remove remove-share clean
+.PHONY: help lint build build-share deploy deploy-share test remove remove-functions remove-share clean
 
 help:
-	echo "Available targets: lint build deploy test remove clean"
+	echo "Available targets: lint build deploy test remove remove-functions clean"
 
 lint: venv3 $(NODE_MODULES_DEV)
 	echo "Linting modules..."
@@ -97,6 +97,10 @@ test: check $(NODE_MODULES_DEV)
 
 remove: check
 	echo "Removing modules..."
+	$(BQ) rm -r -f -d $(BQ_DEPLOY_DATASET)
+
+remove-functions: check
+	echo "Removing functions..."
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	GOOGLE_APPLICATION_CREDENTIALS=$(GOOGLE_APPLICATION_CREDENTIALS) \
 	$(COMMON_DIR)/run-script.js $(COMMON_DIR)/DROP_FUNCTIONS.sql

--- a/clouds/postgres/modules/Makefile
+++ b/clouds/postgres/modules/Makefile
@@ -21,10 +21,10 @@ include $(COMMON_DIR)/Makefile
 
 .SILENT:
 
-.PHONY: help lint build deploy test remove clean
+.PHONY: help lint build deploy test remove remove-functions clean
 
 help:
-	echo "Available targets: lint build deploy test remove clean"
+	echo "Available targets: lint build deploy test remove remove-functions clean"
 
 lint: venv3 $(NODE_MODULES_DEV)
 	echo "Linting modules..."
@@ -61,6 +61,10 @@ test: check venv3 $(NODE_MODULES_DEV)
 
 remove: venv3
 	echo "Removing modules..."
+	$(VENV3_BIN)/python $(COMMON_DIR)/run_query.py "DROP SCHEMA IF EXISTS $(PG_SCHEMA) CASCADE;"
+
+remove-functions: venv3
+	echo "Removing functions..."
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	$(VENV3_BIN)/python $(COMMON_DIR)/run_script.py $(COMMON_DIR)/DROP_FUNCTIONS.sql
 

--- a/clouds/redshift/modules/Makefile
+++ b/clouds/redshift/modules/Makefile
@@ -21,10 +21,10 @@ include $(COMMON_DIR)/Makefile
 
 .SILENT:
 
-.PHONY: help lint build deploy test remove clean
+.PHONY: help lint build deploy test remove remove-functions clean
 
 help:
-	echo "Available targets: lint build deploy test remove clean"
+	echo "Available targets: lint build deploy test remove remove-functions clean"
 
 lint: venv3 $(NODE_MODULES_DEV)
 	echo "Linting modules..."
@@ -61,6 +61,10 @@ test: check venv3 $(NODE_MODULES_DEV)
 
 remove: venv3
 	echo "Removing modules..."
+	$(VENV3_BIN)/python $(COMMON_DIR)/run_query.py "DROP SCHEMA IF EXISTS $(RS_SCHEMA) CASCADE;"
+
+remove-functions: venv3
+	echo "Removing functions..."
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	$(VENV3_BIN)/python $(COMMON_DIR)/run_script.py $(COMMON_DIR)/DROP_FUNCTIONS.sql
 

--- a/clouds/snowflake/modules/Makefile
+++ b/clouds/snowflake/modules/Makefile
@@ -32,10 +32,10 @@ include $(COMMON_DIR)/Makefile
 
 .SILENT:
 
-.PHONY: help lint build build-share build-native-app-setup-script deploy deploy-share test remove remove-share clean
+.PHONY: help lint build build-share build-native-app-setup-script deploy deploy-share test remove remove-functions remove-share clean
 
 help:
-	echo "Available targets: lint build deploy test remove clean"
+	echo "Available targets: lint build deploy test remove remove-functions clean"
 
 lint: $(NODE_MODULES_DEV) venv3
 	echo "Linting modules..."
@@ -107,6 +107,10 @@ test: check $(NODE_MODULES_DEV)
 
 remove: $(NODE_MODULES_DEV)
 	echo "Removing modules..."
+	$(COMMON_DIR)/run-query.js "DROP SCHEMA IF EXISTS $(SF_SCHEMA) CASCADE;"
+
+remove-functions: $(NODE_MODULES_DEV)
+	echo "Removing functions..."
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	$(COMMON_DIR)/run-script.js $(COMMON_DIR)/DROP_FUNCTIONS.sql
 


### PR DESCRIPTION
# Description

Shortcut

I've noticed that with my changes in: https://github.com/CartoDB/analytics-toolbox-core/pull/466 when dedicateds were removed, only the functions were removed instead of the whole schema.

I've restored `make remove` as it was before and added `make remove-functions` to only removed functions for development purposes.

Also have found bug in redshift dedicateds.

## Type of change

- Fix

# Acceptance

Tested to run in the different providers/modules folder:
```
make remove-functions
```

Also tried to create and remove dedicated and see how the schemas gets removed.
