### PR TITLE
docs(bq,sf,rs|processing): update voronoi doc

### DIFF
--- a/clouds/bigquery/modules/doc/processing/ST_DELAUNAYLINES.md
+++ b/clouds/bigquery/modules/doc/processing/ST_DELAUNAYLINES.md
@@ -12,6 +12,12 @@ Calculates the Delaunay triangulation of the points provided. An array of line s
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting polygons (about 1 meter). This can also result in some points being merged together, so that fewer polygons than expected may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY<GEOGRAPHY>`

--- a/clouds/bigquery/modules/doc/processing/ST_DELAUNAYLINES.md
+++ b/clouds/bigquery/modules/doc/processing/ST_DELAUNAYLINES.md
@@ -15,7 +15,7 @@ Due to technical limitations of the underlying libraries used, the input points'
 ````hint:warning
 **warning**
 
-The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+The maximum number of points typically used to compute Delaunay diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
 ````
 
 **Return type**

--- a/clouds/bigquery/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
+++ b/clouds/bigquery/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
@@ -15,7 +15,7 @@ Due to technical limitations of the underlying libraries used, the input points'
 ````hint:warning
 **warning**
 
-The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+The maximum number of points typically used to compute Delaunay diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
 ````
 
 **Return type**

--- a/clouds/bigquery/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
+++ b/clouds/bigquery/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
@@ -12,6 +12,12 @@ Calculates the Delaunay triangulation of the points provided. An array of polygo
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting polygons (about 1 meter). This can also result in some points being merged together, so that fewer polygons than expected may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY<GEOGRAPHY>`

--- a/clouds/bigquery/modules/doc/processing/ST_VORONOILINES.md
+++ b/clouds/bigquery/modules/doc/processing/ST_VORONOILINES.md
@@ -13,6 +13,12 @@ Calculates the Voronoi diagram of the points provided. An array of lines is retu
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting lines (about 1 meter). This can also result in some points being merged together, so that fewer lines than input points may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY<GEOGRAPHY>`

--- a/clouds/bigquery/modules/doc/processing/ST_VORONOIPOLYGONS.md
+++ b/clouds/bigquery/modules/doc/processing/ST_VORONOIPOLYGONS.md
@@ -13,6 +13,12 @@ Calculates the Voronoi diagram of the points provided. An array of polygons is r
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting polygons (about 1 meter). This can also result in some points being merged together, so that fewer polygons than input points may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY<GEOGRAPHY>`

--- a/clouds/redshift/modules/doc/processing/ST_DELAUNAYLINES.md
+++ b/clouds/redshift/modules/doc/processing/ST_DELAUNAYLINES.md
@@ -13,7 +13,7 @@ Calculates the Delaunay triangulation of the points provided. A MultiLineString 
 ````hint:warning
 **warning**
 
-The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+The maximum number of points typically used to compute Delaunay diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
 ````
 
 **Return type**

--- a/clouds/redshift/modules/doc/processing/ST_DELAUNAYLINES.md
+++ b/clouds/redshift/modules/doc/processing/ST_DELAUNAYLINES.md
@@ -10,6 +10,12 @@ Calculates the Delaunay triangulation of the points provided. A MultiLineString 
 
 * `points`: `GEOMETRY` MultiPoint input to the Delaunay triangulation.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `VARCHAR(MAX)`

--- a/clouds/redshift/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
+++ b/clouds/redshift/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
@@ -10,6 +10,12 @@ Calculates the Delaunay triangulation of the points provided. A MultiPolygon obj
 
 * `points`: `GEOMETRY` MultiPoint input to the Delaunay triangulation.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `VARCHAR(MAX)`

--- a/clouds/redshift/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
+++ b/clouds/redshift/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
@@ -13,7 +13,7 @@ Calculates the Delaunay triangulation of the points provided. A MultiPolygon obj
 ````hint:warning
 **warning**
 
-The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+The maximum number of points typically used to compute Delaunay diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
 ````
 
 **Return type**

--- a/clouds/redshift/modules/doc/processing/ST_VORONOILINES.md
+++ b/clouds/redshift/modules/doc/processing/ST_VORONOILINES.md
@@ -10,6 +10,12 @@ Calculates the Voronoi diagram of the points provided. A MultiLineString object 
 
 * `points`: `GEOMETRY` MultiPoint input to the Voronoi diagram.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `VARCHAR(MAX)`

--- a/clouds/redshift/modules/doc/processing/ST_VORONOIPOLYGONS.md
+++ b/clouds/redshift/modules/doc/processing/ST_VORONOIPOLYGONS.md
@@ -10,6 +10,12 @@ Calculates the Voronoi diagram of the points provided. A MultiPolygon object is 
 
 * `points`: `GEOMETRY` MultiPoint input to the Voronoi diagram.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `VARCHAR(MAX)`

--- a/clouds/snowflake/modules/doc/processing/ST_DELAUNAYLINES.md
+++ b/clouds/snowflake/modules/doc/processing/ST_DELAUNAYLINES.md
@@ -12,6 +12,12 @@ Calculates the Delaunay triangulation of the points provided. An array of linest
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting polygons (about 1 meter). This can also result in some points being merged together, so that fewer polygons than expected may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY`

--- a/clouds/snowflake/modules/doc/processing/ST_DELAUNAYLINES.md
+++ b/clouds/snowflake/modules/doc/processing/ST_DELAUNAYLINES.md
@@ -15,7 +15,7 @@ Due to technical limitations of the underlying libraries used, the input points'
 ````hint:warning
 **warning**
 
-The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+The maximum number of points typically used to compute Delaunay diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
 ````
 
 **Return type**

--- a/clouds/snowflake/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
+++ b/clouds/snowflake/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
@@ -12,6 +12,12 @@ Calculates the Delaunay triangulation of the points provided. An array of polygo
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting polygons (about 1 meter). This can also result in some points being merged together, so that fewer polygons than expected may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY`

--- a/clouds/snowflake/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
+++ b/clouds/snowflake/modules/doc/processing/ST_DELAUNAYPOLYGONS.md
@@ -15,7 +15,7 @@ Due to technical limitations of the underlying libraries used, the input points'
 ````hint:warning
 **warning**
 
-The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+The maximum number of points typically used to compute Delaunay diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
 ````
 
 **Return type**

--- a/clouds/snowflake/modules/doc/processing/ST_VORONOILINES.md
+++ b/clouds/snowflake/modules/doc/processing/ST_VORONOILINES.md
@@ -13,6 +13,12 @@ Calculates the Voronoi diagram of the points provided. An array of linestrings i
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting lines (about 1 meter). This can also result in some points being merged together, so that fewer lines than input points may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY`

--- a/clouds/snowflake/modules/doc/processing/ST_VORONOIPOLYGONS.md
+++ b/clouds/snowflake/modules/doc/processing/ST_VORONOIPOLYGONS.md
@@ -13,6 +13,12 @@ Calculates the Voronoi diagram of the points provided. An array of polygons in G
 
 Due to technical limitations of the underlying libraries used, the input points' coordinates are truncated to 5 decimal places in order to avoid problems that happen with close but distinct input points. This limits the precision of the results and can alter slightly the position of the resulting polygons (about 1 meter). This can also result in some points being merged together, so that fewer polygons than input points may result.
 
+````hint:warning
+**warning**
+
+The maximum number of points typically used to compute Voronoi diagrams is 300,000. This limit ensures efficient computation while maintaining accuracy in delineating regions based on proximity to specified points.
+````
+
 **Return type**
 
 `ARRAY`


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/397997/internal-st-voronoi-running-into-memory-limitations#activity-398943
- Autolink: [sc-397997]

Added the doc described in the ticked about Voronoi limitation for Bigquery, Snowflake and Redshift.
In Redshift for now it doesn't make a lot of sense because users will face first the VARCHAR size limitation. But for consistency and in case Redshift upgrades the size I've included it there too.

## Type of change

- Documentation
