### PR TITLE
chore: update snowflake create-package and licenses year

### DIFF
--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -154,7 +154,6 @@ jobs:
     timeout-minutes: 10
     env:
       PACKAGE_BUCKET: gs://carto-analytics-toolbox-core/snowflake
-      SF_DATABASE: 'carto'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 SPDX short identifier: BSD-3-Clause
 
-Copyright (c) 2021-2022, CARTO
+Copyright (c) 2021-2024, CARTO
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/clouds/bigquery/common/DROP_FUNCTIONS.sql
+++ b/clouds/bigquery/common/DROP_FUNCTIONS.sql
@@ -1,5 +1,5 @@
 ---------------------------------
--- Copyright (C) 2021-2023 CARTO
+-- Copyright (C) 2021-2024 CARTO
 ---------------------------------
 
 CREATE OR REPLACE PROCEDURE `@@BQ_DATASET@@.DROP_FUNCTIONS`()

--- a/clouds/postgres/common/DROP_FUNCTIONS.sql
+++ b/clouds/postgres/common/DROP_FUNCTIONS.sql
@@ -1,5 +1,5 @@
 ---------------------------------
--- Copyright (C) 2021-2023 CARTO
+-- Copyright (C) 2021-2024 CARTO
 ---------------------------------
 
 CREATE OR REPLACE PROCEDURE @@PG_SCHEMA@@.__DROP_FUNCTIONS

--- a/clouds/redshift/common/DROP_FUNCTIONS.sql
+++ b/clouds/redshift/common/DROP_FUNCTIONS.sql
@@ -1,5 +1,5 @@
 ---------------------------------
--- Copyright (C) 2021-2023 CARTO
+-- Copyright (C) 2021-2024 CARTO
 ---------------------------------
 
 CREATE OR REPLACE PROCEDURE @@RS_SCHEMA@@.__CREATE_DROP_TABLE

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -96,7 +96,7 @@ clean-modules:
 	$(MAKE) -C modules clean
 
 create-package:
-	$(MAKE) build production=1 dropfirst=1
+	$(MAKE) build production=1 dropfirst=1 database=CARTO
 
 	rm -rf $(DIST_DIR)
 	mkdir -p $(DIST_DIR)/$(PACKAGE_NAME)

--- a/clouds/snowflake/common/DROP_FUNCTIONS.sql
+++ b/clouds/snowflake/common/DROP_FUNCTIONS.sql
@@ -1,5 +1,5 @@
 ---------------------------------
--- Copyright (C) 2021-2023 CARTO
+-- Copyright (C) 2021-2024 CARTO
 ---------------------------------
 
 CREATE OR REPLACE PROCEDURE @@SF_SCHEMA@@._DROP_FUNCTIONS()

--- a/clouds/snowflake/common/Makefile
+++ b/clouds/snowflake/common/Makefile
@@ -4,11 +4,15 @@ PYTHON3_VERSION = 3
 VENV3_DIR ?= $(COMMON_DIR)/../venv3
 VENV3_BIN = $(VENV3_DIR)/bin
 NODE_MODULES_DEV = $(COMMON_DIR)/node_modules
-export SF_SCHEMA_DEFAULT = carto
+export SF_SCHEMA_DEFAULT = CARTO
 
 ifneq (,$(wildcard $(ENV_DIR)/.env))
     include $(ENV_DIR)/.env
 	export $(shell sed 's/=.*//' $(ENV_DIR)/.env)
+endif
+
+ifdef database
+export SF_DATABASE = $(database)
 endif
 
 ifeq ($(production),1)


### PR DESCRIPTION
# Description

- Make `create-package` command not dependent on SF_DATABASE variable.
- Update licenses year to 2024 in all required files and headers.
