### PR TITLE
Fix DB Connection Error in tests when % character in PG_PASSWORD

### DIFF
--- a/clouds/postgres/common/test_utils/__init__.py
+++ b/clouds/postgres/common/test_utils/__init__.py
@@ -5,6 +5,7 @@ import geopandas as gpd
 import pandas as pd
 import psycopg2
 
+from urllib.parse import quote_plus
 from shapely import wkt
 from sqlalchemy import create_engine
 
@@ -15,6 +16,13 @@ PG_CONFIG = {
     'password': os.environ['PG_PASSWORD'],
     'port': 5432,
 }
+URL_PG_CONFIG = {
+    'host': os.environ['PG_HOST'],
+    'database': os.environ['PG_DATABASE'],
+    'user': os.environ['PG_USER'],
+    'password': quote_plus(os.environ['PG_PASSWORD']),
+    'port': 5432,
+}
 
 conn = psycopg2.connect(**PG_CONFIG)
 conn.autocommit = (
@@ -22,7 +30,7 @@ conn.autocommit = (
 )
 
 connection_string = 'postgresql://{user}:{password}@{host}:{port}/{database}'.format(
-    **PG_CONFIG
+    **URL_PG_CONFIG
 )
 engine = create_engine(connection_string)
 


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/409939
- Autolink: [sc-409939]

Please include a summary of the change. If required, also include relevant info about motivation and context... And if PR includes UI elements (or if it helps for understanding it), please add extra files: snapshots, videos...

## Type of change

- Fix


# Acceptance
To recreate issue:

1. Set PG_USER's password to include `%` character
2. From the  `analytics-toolbox` project, run `cd clouds/postgres && make test`
3. It will fail due to a bad password in the connection_string in submodule `core/clouds/postgres/common/test_utils/__init__.py
4. Checkout this branch in `core` and rerun. The tests should run fine
