### PR TITLE
fix(pg): lock numpy to v1.24.4 until pandas supports 2.X.X

### DIFF
--- a/clouds/postgres/common/python3_requirements.txt
+++ b/clouds/postgres/common/python3_requirements.txt
@@ -14,4 +14,4 @@ pandas==1.3.2
 SQLAlchemy==1.4.23
 mapbox-vector-tile==1.2.1
 sqlfluff==1.3.1
-
+numpy==1.24.4


### PR DESCRIPTION
# Description

Shortcut

- Story:https://app.shortcut.com/cartoteam/story/434862/pg-pandas-geopandas-are-incompatible-with-new-numpy-2-x-x-releases-breaking-c-api-changes
- Autolink: [sc-434862]

Pandas doesn't fully support numpy 2+ . Our unit tests encounter a breaking change with the C API.

```
make[1]: Entering directory '/home/dean/development/analytics-toolbox/clouds/postgres'
make[2]: Entering directory '/home/dean/development/analytics-toolbox/clouds/postgres/libraries/javascript'
make[2]: Leaving directory '/home/dean/development/analytics-toolbox/clouds/postgres/libraries/javascript'
make[1]: Leaving directory '/home/dean/development/analytics-toolbox/clouds/postgres'
make[1]: Entering directory '/home/dean/development/analytics-toolbox/clouds/postgres'
make[2]: Entering directory '/home/dean/development/analytics-toolbox/clouds/postgres/modules'
Testing modules...
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.9.19, pytest-6.2.4, py-1.11.0, pluggy-0.13.1 -- /home/dean/development/analytics-toolbox/clouds/postgres/venv3/bin/python
cachedir: .pytest_cache
rootdir: /home/dean/development/analytics-toolbox/clouds/postgres/modules
collected 0 items / 1 error                                                                                                                                                                                        

====================================================================================================== ERRORS ======================================================================================================
\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_ ERROR collecting test/tiler/test_CREATE_POINT_AGGREGATION_TILESET.py \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:986: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:680: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:850: in exec_module
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
test/tiler/__init__.py:5: in <module>
    from test_utils import (  # noqa: E402
../../../core/clouds/postgres/common/test_utils/__init__.py:4: in <module>
    import geopandas as gpd
../venv3/lib/python3.9/site-packages/geopandas/__init__.py:1: in <module>
    from geopandas._config import options  # noqa
../venv3/lib/python3.9/site-packages/geopandas/_config.py:126: in <module>
    default_value=_default_use_pygeos(),
../venv3/lib/python3.9/site-packages/geopandas/_config.py:112: in _default_use_pygeos
    import geopandas._compat as compat
../venv3/lib/python3.9/site-packages/geopandas/_compat.py:7: in <module>
    import pandas as pd
../venv3/lib/python3.9/site-packages/pandas/__init__.py:22: in <module>
    from pandas.compat import (
../venv3/lib/python3.9/site-packages/pandas/compat/__init__.py:15: in <module>
    from pandas.compat.numpy import (
../venv3/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:7: in <module>
    from pandas.util.version import Version
../venv3/lib/python3.9/site-packages/pandas/util/__init__.py:1: in <module>
    from pandas.util._decorators import (  # noqa
../venv3/lib/python3.9/site-packages/pandas/util/_decorators.py:14: in <module>
    from pandas._libs.properties import cache_readonly  # noqa
../venv3/lib/python3.9/site-packages/pandas/_libs/__init__.py:13: in <module>
    from pandas._libs.interval import Interval
pandas/_libs/interval.pyx:1: in init pandas._libs.interval
    ???
E   ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```


This can also be recreated by doing:
```
cd clouds/postgres
source venv3/bin/activate
python

>> import geopandas   # errors as above
```

More info here: https://github.com/numpy/numpy/issues/26710


Also: because CI uses python 3.8 to run tests we have to lock it at 1.24.4. If we were using python3.9+ on CI we could use 1.26.4 (last release of numpy 1). 

## Type of change

- Fix

# Acceptance

1. fresh clone of AT (optional - you could just `rm -r venv3/`)
2. run `make test` in `clouds/postgres` - it will error with a stacktrace as above
3. checkout `pg-pandas-geopandas-are-incompatible-with`
4. run `make test` again and they will run + pass

Note: this bug also affects analytics-toolbox (premium). This fix in core will fix core and premium. 

I'm not sure why CI hasn't failed yet. Maybe dependencies are cached.

# Basic checklist

- Good PR name
- Shortcut link
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
