### PR TITLE
chore(sf): update python version on stored procedures from 3.8 to 3.9

### DIFF
--- a/clouds/snowflake/native_app/SETUP_SCRIPT.sql
+++ b/clouds/snowflake/native_app/SETUP_SCRIPT.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE PROCEDURE @@SF_APP_SCHEMA@@.GET_MODULES_SQL_FROM_STAGE()
     returns string
     language python
-    runtime_version = '3.8'
+    RUNTIME_VERSION = '3.9'
     packages = ('snowflake-snowpark-python')
     imports = (
         '/get_modules_sql_from_stage.py',


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/441537/update-python-version-in-snowflake-procedures
- Autolink: [sc-441537]

We have received a message from the Snowflake team that using the version 3.8 will get depecrated in stored procedures.

## Type of change

- Fix

# Acceptance

- Checked that the Native app was succesfully installed locally.