### PR TITLE
chore(sf): deploy snowflake in CARTO.CARTO when releasing

### DIFF
--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -88,6 +88,39 @@ jobs:
           cd clouds/snowflake
           make deploy diff="$GIT_DIFF" production=1
 
+  deploy-internal-stable:
+    if: github.ref_name == 'stable'
+    needs: test
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        include:
+          - account: SF_ACCOUNT_CD
+            database: SF_DATABASE_STABLE_CD
+            user: SF_USER_CD
+            password: SF_PASSWORD_CD
+            role: SF_ROLE_CD
+    env:
+      SF_ACCOUNT: ${{ secrets[matrix.account] }}
+      SF_DATABASE: ${{ secrets[matrix.database] }}
+      SF_USER: ${{ secrets[matrix.user] }}
+      SF_PASSWORD: ${{ secrets[matrix.password] }}
+      SF_ROLE: ${{ secrets[matrix.role] }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Check diff
+        uses: technote-space/get-diff-action@v4
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Run deploy
+        run: |
+          cd clouds/snowflake
+          make deploy diff="$GIT_DIFF" production=1
+
   deploy-internal-app:
     if: github.ref_name == 'main'
     needs: test


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/450304/deploy-analytics-toolbox-release-into-carto-carto-snowflake
- Autolink: [sc-450304]

We were required to deploy the AT in CARTO.CARTO after every release a new secret `SF_DATABASE_STABLE_CD` as been added.

## Type of change

- Refactor