### PR TITLE
docs(sf|h3): update h3_polyfill_table docs as it does not support points or lines

### DIFF
--- a/clouds/snowflake/modules/doc/h3/H3_POLYFILL_TABLE.md
+++ b/clouds/snowflake/modules/doc/h3/H3_POLYFILL_TABLE.md
@@ -6,15 +6,14 @@ H3_POLYFILL_TABLE(input_query, resolution, mode, output_table)
 
 **Description**
 
-Returns a table with the H3 cell indexes contained in the given geography at a requested resolution. Containment is determined by the mode: center, intersects, contains. All the attributes except the geography will be included in the output table, clustered by the h3 column.
+Returns a table with the H3 cell indexes contained in the given polygon at a requested resolution. Containment is determined by the mode: center, intersects, contains. All the attributes except the polygon will be included in the output table, clustered by the h3 column.
 
 * `input_query`: `STRING` input data to polyfill. It must contain a column `geom` with the shape to cover. Additionally, other columns can be included.
-* `resolution`: `INT` level of detail. The value must be between 0 and 15 ([H3 resolution table](https://h3geo.org/docs/core-library/restable)).
-* `mode`: `STRING`
-  * `center` returns the indexes of the H3 cells which centers intersect the input geography (polygon). The resulting H3 set does not fully cover the input geography, however, this is **significantly faster** that the other modes. This mode is not compatible with points or lines. Equivalent to [`H3_POLYFILL`](h3#h3_polyfill).
-  * `intersects` returns the indexes of the H3 cells that intersect the input geography. The resulting H3 set will completely cover the input geography (point, line, polygon).
-  * `contains` returns the indexes of the H3 cells that are entirely contained inside the input geography (polygon). This mode is not compatible with points or lines.
-* `output_table`: `STRING` name of the output table to store the results of the polyfill.
+* `resolution`: `INT` number between 0 and 15 with the [H3 resolution](https://h3geo.org/docs/core-library/restable).
+* `mode`: `STRING` `<center|contains|intersects>`. Optional. Defaults to 'center' mode.
+  * `center` The center point of the H3 cell must be within the polygon
+  * `contains` The H3 cell must be fully contained within the polygon (least inclusive)
+  * `intersects` The H3 cell intersects in any way with the polygon (most inclusive)
 
 Mode `center`:
 


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/458801/update-docs-for-h3-polyfill-table-to-only-support-polygons-in-snowflake
- Autolink: [sc-458801]

## Type of change

- Documentation