### PR TITLE
chore(bq): allow supporting multiple libraries in one line

### DIFF
--- a/clouds/bigquery/common/build_modules.js
+++ b/clouds/bigquery/common/build_modules.js
@@ -159,7 +159,7 @@ if (argv.production) {
 let content = output.map(f => f.content).join(separator);
 
 function apply_replacements (text) {
-    const libraries = [... new Set(text.match(new RegExp('@@BQ_LIBRARY_.*_BUCKET@@', 'g')))];
+    const libraries = [... new Set(content.match(new RegExp('@@BQ_LIBRARY_[^@]*?_BUCKET@@', 'g')))];
     for (let library of libraries) {
         let libraryName = library.replace('@@BQ_LIBRARY_', '').replace('_BUCKET@@', '').toLowerCase();
         if (makelib == libraryName) {

--- a/clouds/bigquery/common/list_libraries.js
+++ b/clouds/bigquery/common/list_libraries.js
@@ -134,7 +134,7 @@ function add (f, include) {
 functions.forEach(f => add(f));
 
 const content = output.map(f => f.content).join('\n');
-let libraries = [... new Set(content.match(new RegExp('@@BQ_LIBRARY_.*_BUCKET@@', 'g')))]
+let libraries = [... new Set(content.match(new RegExp('@@BQ_LIBRARY_[^@]*?_BUCKET@@', 'g')))]
     .map(l => l.replace('@@BQ_LIBRARY_', '').replace('_BUCKET@@', '').toLowerCase());
 
 // Exclude libraries pointed by makelib as they are deployed separately


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/463939/split-js-libraries-creation-into-different-files-in-bigquery
- Autolink: [sc-463939]

This should be part of this other PR: https://github.com/CartoDB/analytics-toolbox-core/pull/541

## Type of change

- Refactor

# Acceptance

Tested by deploying in local some raster functions that includes multiple libraries.
https://github.com/CartoDB/analytics-toolbox/pull/930