### PR TITLE
chore(sf): SF_ACCOUNT no longer follows "account.region" format

### DIFF
--- a/clouds/snowflake/common/Makefile
+++ b/clouds/snowflake/common/Makefile
@@ -38,8 +38,8 @@ endif
 ifndef SF_PASSWORD
 	$(error SF_PASSWORD is undefined)
 endif
-ifeq ($(shell echo "$(SF_ACCOUNT)" | grep -E "^([^.]+)\.([^.]+)$$"),)
-	$(error SF_ACCOUNT is not valid. Must be: <account>.<region>)
+ifndef SF_ACCOUNT
+	$(error SF_ACCOUNT is undefined)
 endif
 
 venv3:


### PR DESCRIPTION
# Description

Shortcut

By doing some tests with Trial accounts detected that the host is no longer identified by `account.region`, the account identifier can be `organizationname-accountname`. For instance: HDKHROX-VAB74276. This fix unblock deployment into trial accounts.

## Type of change

- Refactor

# Acceptance

Tested it by deploying locally.