### PR TITLE
Upgrade ubuntu-20.04 to ubuntu-24.04 runner version

### DIFF
--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.label.name == 'dedicated_bigquery' ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'dedicated_bigquery')) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dedicated_bigquery'))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       GCLOUD_VERSION: 500.0.0

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -23,7 +23,7 @@ env:
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       BQ_PREFIX: ci_${{ github.sha }}_${{ github.run_id }}_${{ github.run_attempt }}_
@@ -67,7 +67,7 @@ jobs:
   deploy-internal:
     if: github.ref_name == 'main'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -103,7 +103,7 @@ jobs:
   deploy:
     if: github.ref_name == 'stable'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -148,7 +148,7 @@ jobs:
   publish:
     if: github.ref_name == 'stable'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
       PACKAGE_BUCKET: gs://carto-analytics-toolbox-core/bigquery

--- a/.github/workflows/databricks.yml
+++ b/.github/workflows/databricks.yml
@@ -24,7 +24,7 @@ jobs:
 
   test:
     if: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       DB_PREFIX: ci_${{ github.sha }}_${{ github.run_id }}_${{ github.run_attempt }}_
@@ -71,7 +71,7 @@ jobs:
   deploy-internal:
     if: github.ref_name == 'main'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -120,7 +120,7 @@ jobs:
   publish:
     needs: test
     if: github.ref_name == 'stable'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
       PACKAGE_BUCKET: gs://carto-analytics-toolbox-core/databricks

--- a/.github/workflows/postgres-ded.yml
+++ b/.github/workflows/postgres-ded.yml
@@ -16,7 +16,7 @@ jobs:
       github.event.label.name == 'dedicated_postgres' ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'dedicated_postgres')) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dedicated_postgres'))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       PG_HOST: ${{ secrets.PG_HOST_CD }}

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -23,7 +23,7 @@ env:
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       PG_PREFIX: ci_${{ github.sha }}_${{ github.run_id }}_${{ github.run_attempt }}_
@@ -57,7 +57,7 @@ jobs:
   deploy-internal:
     if: github.ref_name == 'main'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -98,7 +98,7 @@ jobs:
   publish:
     if: github.ref_name == 'stable'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
       PACKAGE_BUCKET: gs://carto-analytics-toolbox-core/postgres

--- a/.github/workflows/redshift-ded.yml
+++ b/.github/workflows/redshift-ded.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.label.name == 'dedicated_redshift' ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'dedicated_redshift')) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dedicated_redshift'))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: python:2.7.18-buster
     timeout-minutes: 20
     env:

--- a/.github/workflows/redshift.yml
+++ b/.github/workflows/redshift.yml
@@ -24,7 +24,7 @@ env:
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: python:2.7.18-buster
     timeout-minutes: 30
     env:
@@ -75,7 +75,7 @@ jobs:
   deploy-internal:
     if: github.ref_name == 'main'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: python:2.7.18-buster
     timeout-minutes: 20
     strategy:
@@ -142,7 +142,7 @@ jobs:
   publish:
     if: github.ref_name == 'stable'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: python:2.7.18-buster
     timeout-minutes: 10
     env:

--- a/.github/workflows/snowflake-ded.yml
+++ b/.github/workflows/snowflake-ded.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.label.name == 'dedicated_snowflake' ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'dedicated_snowflake')) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dedicated_snowflake'))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       SF_ACCOUNT: ${{ secrets.SF_ACCOUNT_CD }}

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -23,7 +23,7 @@ env:
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       SF_PREFIX: ci_${{ github.sha }}_${{ github.run_id }}_${{ github.run_attempt }}_
@@ -58,7 +58,7 @@ jobs:
   deploy-internal:
     if: github.ref_name == 'main'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -91,7 +91,7 @@ jobs:
   deploy-internal-stable:
     if: github.ref_name == 'stable'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -124,7 +124,7 @@ jobs:
   deploy-internal-app:
     if: github.ref_name == 'main'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       APP_PACKAGE_NAME: ${{ secrets.SF_NATIVE_APP_PACKAGE_NAME_CD }}
@@ -155,7 +155,7 @@ jobs:
   deploy-share:
     if: github.ref_name == 'stable'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       SF_ACCOUNT: ${{ secrets.SF_ACCOUNT_SHARE }}
@@ -183,7 +183,7 @@ jobs:
   publish:
     if: github.ref_name == 'stable'
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
       PACKAGE_BUCKET: gs://carto-analytics-toolbox-core/snowflake


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/470573
- Autolink: [sc-470573]

In order to avoid deprecation and our CI/CD not running because we are using runners deprecated upgrade to the latest version available.