### PR TITLE
chore(ora): allow block-comment extra-dependency convention [sc-547413]

### DIFF
--- a/clouds/oracle/common/build_modules.js
+++ b/clouds/oracle/common/build_modules.js
@@ -71,22 +71,12 @@ for (let inputDir of inputDirs) {
             files.forEach(file => {
                 if (file.endsWith('.sql')) {
                     const name = path.parse(file).name;
-                    const rawContent = fs.readFileSync(path.join(moduledir, file)).toString();
-                    // Parse @extra-dependency annotations before stripping comments
-                    // Format: -- @extra-dependency FUNCTION_NAME
-                    const extraDeps = [];
-                    const extraDepPattern = /@extra-dependency\s+(\S+)/g;
-                    let match;
-                    while ((match = extraDepPattern.exec(rawContent)) !== null) {
-                        extraDeps.push(match[1]);
-                    }
-                    const content = rawContent.replace(/--.*\n/g, '');
+                    const content = fs.readFileSync(path.join(moduledir, file)).toString().replace(/--.*\n/g, '');
                     functions.push({
                         name,
                         module,
                         content,
-                        dependencies: [],
-                        extraDependencies: extraDeps
+                        dependencies: []
                     });
                 }
             });
@@ -116,12 +106,6 @@ if (!nodeps) {
                 if (mainFunction.content.includes(`SCHEMA@@.${depFunction.name}(`)) {
                     mainFunction.dependencies.push(depFunction.name);
                 }
-            }
-        });
-        // Add @extra-dependency annotations
-        mainFunction.extraDependencies.forEach(dep => {
-            if (!mainFunction.dependencies.includes(dep)) {
-                mainFunction.dependencies.push(dep);
             }
         });
     });

--- a/clouds/oracle/common/build_modules.js
+++ b/clouds/oracle/common/build_modules.js
@@ -71,12 +71,22 @@ for (let inputDir of inputDirs) {
             files.forEach(file => {
                 if (file.endsWith('.sql')) {
                     const name = path.parse(file).name;
-                    const content = fs.readFileSync(path.join(moduledir, file)).toString().replace(/--.*\n/g, '');
+                    const rawContent = fs.readFileSync(path.join(moduledir, file)).toString();
+                    // Parse @extra-dependency annotations before stripping comments
+                    // Format: -- @extra-dependency FUNCTION_NAME
+                    const extraDeps = [];
+                    const extraDepPattern = /@extra-dependency\s+(\S+)/g;
+                    let match;
+                    while ((match = extraDepPattern.exec(rawContent)) !== null) {
+                        extraDeps.push(match[1]);
+                    }
+                    const content = rawContent.replace(/--.*\n/g, '');
                     functions.push({
                         name,
                         module,
                         content,
-                        dependencies: []
+                        dependencies: [],
+                        extraDependencies: extraDeps
                     });
                 }
             });
@@ -106,6 +116,12 @@ if (!nodeps) {
                 if (mainFunction.content.includes(`SCHEMA@@.${depFunction.name}(`)) {
                     mainFunction.dependencies.push(depFunction.name);
                 }
+            }
+        });
+        // Add @extra-dependency annotations
+        mainFunction.extraDependencies.forEach(dep => {
+            if (!mainFunction.dependencies.includes(dep)) {
+                mainFunction.dependencies.push(dep);
             }
         });
     });

--- a/clouds/oracle/common/run_script.py
+++ b/clouds/oracle/common/run_script.py
@@ -72,6 +72,9 @@ def execute_script(script_path):
 
         # Remove line comments
         sql = re.sub(r'--.*\n', '\n', sql)
+        # Remove block comments — Oracle's '/' statement terminator collides
+        # with the closing '*/' if they stay in the script
+        sql = re.sub(r'/\*.*?\*/', '', sql, flags=re.DOTALL)
 
         # Execute SQL (split by statement terminator)
         cursor = connection.cursor()


### PR DESCRIPTION
## Summary

- https://app.shortcut.com/cartoteam/story/547413/oracle-allow-block-comment-extra-dependency-convention-align-with-bq-sf-pg
- Align Oracle with the `/* Extra dependencies: ... */` convention already used by BigQuery, Snowflake, and Postgres.

## Problem

Oracle's diff-based builds only include functions that are direct code dependencies (detected via `SCHEMA@@.{name}(` substring match). Some dependencies are not code-level — for example, `INTERNAL_CREATE_BUILDER_MAP` requires `SETUP` to be deployed (it configures the gateway), but never calls it in code. On a fresh CI schema with a map-only diff, SETUP isn't included in `modules.sql`, and the post-deploy gateway-config step fails with `PLS-00201: identifier 'SETUP' must be declared`.

Discovered during [analytics-toolbox PR #1072](https://github.com/CartoDB/analytics-toolbox/pull/1072).

## Solution (revised from original `@extra-dependency` annotation approach)

BigQuery/Snowflake/Postgres already declare non-code dependencies in a block comment:

```sql
/*
Extra dependencies:
`@@BQ_DATASET@@.SETUP`()
*/
```

This works with **zero parsing logic** because:
- The dep scanner (`content.includes('SCHEMA@@.<name>(')`) already picks up references found inside block comments.
- Only `--` comments are stripped from content; block comments survive into the scan.

Documented in `core/CONTRIBUTING.md`.

For Oracle, block comments were previously unsafe because Oracle uses `/` as the PL/SQL statement terminator and `run_script.py` splits on `'/\n'` — which collides with `*/\n` at the end of a block comment, cutting the comment mid-way and corrupting statement splitting.

## Change

Strip block comments in `run_script.py` **before** the statement splitter runs (3-line diff):

```python
# Remove line comments
sql = re.sub(r'--.*\n', '\n', sql)
# Remove block comments — Oracle's '/' statement terminator collides
# with the closing '*/' if they stay in the script
sql = re.sub(r'/\*.*?\*/', '', sql, flags=re.DOTALL)
```

`build_modules.js` is **unchanged** — the existing substring-based dep detector already picks up references inside surviving block comments.

## Why this over the original annotation approach?

|  | Original `@extra-dependency` annotation | Block-comment convention |
|---|---|---|
| Consistency across clouds | New Oracle-specific style | Matches BQ / SF / PG |
| `build_modules.js` delta | +18 / −2 (new regex, new array, merge step) | 0 |
| `run_script.py` delta | 0 | +3 |
| Typo crash (Gemini #1) | Needs explicit validation | N/A — unresolved names simply don't match any function |
| String-literal false positives (Gemini #2) | Needs `--\s*` anchor | N/A — no new regex |
| Last-line-without-newline strip bug (Gemini #3) | Unrelated latent bug | Unrelated latent bug (same in all 6 clouds) |

## Companion change

Once this merges, [analytics-toolbox PR #1072](https://github.com/CartoDB/analytics-toolbox/pull/1072) declares the extra dependency in `clouds/oracle/modules/sql/map/INTERNAL_CREATE_BUILDER_MAP.sql`:

```sql
/*
Extra dependencies:
@@ORA_SCHEMA@@.SETUP()
*/
```

Any future LDS procedure that needs SETUP on fresh schemas follows the same pattern.

## Test plan

```bash
# Build path — verify SETUP is pulled into modules.sql
node core/clouds/oracle/common/build_modules.js \
  "core/clouds/oracle/modules/,clouds/oracle/modules/" \
  --output=build \
  --diff="clouds/oracle/modules/sql/map/INTERNAL_CREATE_BUILDER_MAP.sql"
grep "PROCEDURE.*SETUP" build/modules.sql

# Deploy path — verify block comments are stripped before the statement splitter
python3 -c "
import re
sql = open('build/modules.sql').read()
sql = re.sub(r'--.*\n', '\n', sql)
sql = re.sub(r'/\*.*?\*/', '', sql, flags=re.DOTALL)
print('stmts:', len([s for s in sql.split('/\n') if s.strip()]))
"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
