### PR TITLE
chore(ora): add drop_table helper to test_utils

### DIFF
--- a/clouds/oracle/common/test_utils/__init__.py
+++ b/clouds/oracle/common/test_utils/__init__.py
@@ -82,6 +82,6 @@ def drop_table(*table_names):
     """
     for table_name in table_names:
         try:
-            run_query(f'DROP TABLE {table_name}')
+            run_query(f'DROP TABLE {quote_table_name(table_name)}')
         except Exception:
             pass

--- a/clouds/oracle/common/test_utils/__init__.py
+++ b/clouds/oracle/common/test_utils/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     'run_query',
     'run_queries',
     'get_cursor',
+    'drop_table',
 ]
 
 
@@ -70,3 +71,17 @@ def get_cursor():
     """Get a database cursor for manual operations."""
     conn, _wallet_dir = get_connection()
     return conn.cursor()
+
+
+def drop_table(*table_names):
+    """Drop one or more tables, ignoring non-existent ones.
+
+    Equivalent to DROP TABLE IF EXISTS, which Oracle does not support
+    natively. Accepts @@ORA_SCHEMA@@ placeholders which are resolved by
+    run_query.
+    """
+    for table_name in table_names:
+        try:
+            run_query(f'DROP TABLE {table_name}')
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- Adds a shared `drop_table(*table_names)` helper to Oracle's `test_utils` so test files no longer need to duplicate a local `_cleanup` try/except wrapper in every module.
- Oracle does not support `DROP TABLE IF EXISTS` natively, hence the need for a Python-side helper.
- Matches the naming convention used by Postgres test_utils (`drop_table`); the JS clouds (BigQuery, Snowflake) use the camelCase equivalent (`deleteTable`). Redshift and Databricks don't need a helper because their SQL supports `DROP TABLE IF EXISTS` inline.

## Why now
The Oracle LDS module PR (CartoDB/analytics-toolbox#1064) adds 6 new test files, each with an identical 8-line `_cleanup` duplicate. Landing this helper first lets the module PR remove those duplicates in exchange for a one-line import.

## Test plan
- [ ] `cd clouds/oracle && make test modules=map` — existing Oracle tests continue to pass (they don't use `drop_table` yet, so this is a no-op regression check)
- [ ] Downstream AT PR (#1064) switches its 6 LDS test files to `from test_utils import drop_table` and removes the local `_cleanup` defs

🤖 Generated with [Claude Code](https://claude.com/claude-code)