### PR TITLE
chore(ora): clarify NUMBER(1) usage — not allowed in function RETURN clauses

### DIFF
--- a/.claude/rules/oracle.md
+++ b/.claude/rules/oracle.md
@@ -48,7 +48,7 @@ make remove drop-schema=1      # Drop entire schema (destructive)
 - Pure SQL functions: `CREATE OR REPLACE FUNCTION ... RETURN ... IS BEGIN ... END;` with `/` terminator
 - PL/SQL blocks with loops for complex functions (KRING, TOCHILDREN, POLYFILL)
 - Pipelined functions (`RETURN <type> PIPELINED`, `PIPE ROW(...)`) for size-variable array/struct-array returns
-- No SQL BOOLEAN — use `NUMBER(1)` (1/0) for boolean columns and variables; callers use `= 1`. Function `RETURN` clauses must use plain `NUMBER` (Oracle disallows precision on function return types — `RETURN NUMBER(1)` raises `PLS-00103`)
+- No SQL BOOLEAN — use `NUMBER(1)` (1/0) for boolean columns and local variables; callers use `= 1`. Subprogram parameter and `RETURN` clause types must use plain `NUMBER` (Oracle disallows precision in subprogram signatures — `RETURN NUMBER(1)` or `p NUMBER(1)` raises `PLS-00103`)
 - `AUTHID CURRENT_USER` (invoker rights) for all procedures
 
 ## Oracle Type Mapping (v1.0)
@@ -58,7 +58,7 @@ make remove drop-schema=1      # Drop entire schema (destructive)
 | Generic shape | Oracle type | Notes |
 |---|---|---|
 | scalar INT / FLOAT | `NUMBER` | 38-digit decimal; holds 64-bit ints and floats exactly |
-| scalar BOOL | `NUMBER(1)` (1/0) for columns/variables, plain `NUMBER` for function `RETURN` clauses | no SQL BOOLEAN; callers use `= 1`. Oracle disallows precision on function return types |
+| scalar BOOL | `NUMBER(1)` (1/0) for columns/local variables, plain `NUMBER` for parameters/returns | no SQL BOOLEAN; callers use `= 1`. Oracle disallows precision in subprogram signatures |
 | scalar STRING | `VARCHAR2` | direct |
 | scalar GEOMETRY / GEOGRAPHY | `SDO_GEOMETRY` with explicit SRID 4326 | matches BQ/SF implicit WGS84 |
 | `ARRAY<primitive>` | `TABLE OF <type>` PIPELINED | consume via `TABLE(func(...))` |

--- a/.claude/rules/oracle.md
+++ b/.claude/rules/oracle.md
@@ -48,7 +48,7 @@ make remove drop-schema=1      # Drop entire schema (destructive)
 - Pure SQL functions: `CREATE OR REPLACE FUNCTION ... RETURN ... IS BEGIN ... END;` with `/` terminator
 - PL/SQL blocks with loops for complex functions (KRING, TOCHILDREN, POLYFILL)
 - Pipelined functions (`RETURN <type> PIPELINED`, `PIPE ROW(...)`) for size-variable array/struct-array returns
-- No SQL BOOLEAN — use `NUMBER(1)` (1/0) for boolean returns; callers use `= 1`
+- No SQL BOOLEAN — use `NUMBER(1)` (1/0) for boolean columns and variables; callers use `= 1`. Function `RETURN` clauses must use plain `NUMBER` (Oracle disallows precision on function return types — `RETURN NUMBER(1)` raises `PLS-00103`)
 - `AUTHID CURRENT_USER` (invoker rights) for all procedures
 
 ## Oracle Type Mapping (v1.0)
@@ -58,7 +58,7 @@ make remove drop-schema=1      # Drop entire schema (destructive)
 | Generic shape | Oracle type | Notes |
 |---|---|---|
 | scalar INT / FLOAT | `NUMBER` | 38-digit decimal; holds 64-bit ints and floats exactly |
-| scalar BOOL | `NUMBER(1)` (1/0) | no SQL BOOLEAN; callers use `= 1` |
+| scalar BOOL | `NUMBER(1)` (1/0) for columns/variables, plain `NUMBER` for function `RETURN` clauses | no SQL BOOLEAN; callers use `= 1`. Oracle disallows precision on function return types |
 | scalar STRING | `VARCHAR2` | direct |
 | scalar GEOMETRY / GEOGRAPHY | `SDO_GEOMETRY` with explicit SRID 4326 | matches BQ/SF implicit WGS84 |
 | `ARRAY<primitive>` | `TABLE OF <type>` PIPELINED | consume via `TABLE(func(...))` |


### PR DESCRIPTION
## Summary

The Oracle typing convention introduced in #602 recommends `NUMBER(1)` (1/0) for boolean values. This works for **column declarations** and **variable declarations**, but not for **function `RETURN` clauses** — Oracle PL/SQL disallows precision on function return types.

## Failure mode

Attempting to use `RETURN NUMBER(1)` raises:

```
PLS-00103: Encountered the symbol "(" when expecting one of the following:
   . @ % ; is default authid as cluster order using external
   character deterministic shard_enable parallel_enable
   pipelined aggregate result_cache accessible sql_macro
```

The function is created in `INVALID` state. Every downstream object that depends on it cascades to `INVALID` too. Calls fail with `ORA-06575: Package or function ... is in an invalid state`.

## How it surfaced

Hit while landing the LDS Oracle module (analytics-toolbox#1064). `SETUP.sql` had `RETURN NUMBER(1)` inside an `EXECUTE IMMEDIATE` building `INTERNAL_GENERIC_IS_CONFIGURED`, which compiled to `INVALID` at first call. CI caught it because every LDS function/procedure calling `INTERNAL_GENERIC_IS_CONFIGURED()` became `INVALID` by dependency. The fix in the SETUP file was simple (change to `RETURN NUMBER`), but the rule's wording made the failure mode non-obvious.

## Changes

Two places in `.claude/rules/oracle.md`:

1. The "Oracle SQL Patterns" bullet now reads:
   > use `NUMBER(1)` (1/0) for boolean columns and variables; callers use `= 1`. Function `RETURN` clauses must use plain `NUMBER` (Oracle disallows precision on function return types — `RETURN NUMBER(1)` raises `PLS-00103`)

2. The "scalar BOOL" row in the type-mapping table now reads:
   > `NUMBER(1)` (1/0) for columns/variables, plain `NUMBER` for function `RETURN` clauses

## Test plan

- [ ] Documentation-only change; no code affected
- [ ] Future Oracle modules referencing this rule will see the disambiguated guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)