### PR TITLE
feat(ora|test_utils): add escape_sql helper

### DIFF
--- a/clouds/oracle/common/test_utils/__init__.py
+++ b/clouds/oracle/common/test_utils/__init__.py
@@ -27,6 +27,8 @@ def escape_sql(query):
     every ' inside the query must become ''. Useful in tests that pass a
     SQL fragment as a string parameter.
     """
+    if query is None:
+        return None
     return query.replace("'", "''")
 
 

--- a/clouds/oracle/common/test_utils/__init__.py
+++ b/clouds/oracle/common/test_utils/__init__.py
@@ -15,7 +15,19 @@ __all__ = [
     'run_queries',
     'get_cursor',
     'drop_table',
+    'escape_sql',
 ]
+
+
+def escape_sql(query):
+    """Escape single quotes for embedding inside an Oracle string literal.
+
+    Oracle SQL doubles single quotes inside string literals: e.g. when
+    passing a SELECT query as a VARCHAR2 argument to a stored procedure,
+    every ' inside the query must become ''. Useful in tests that pass a
+    SQL fragment as a string parameter.
+    """
+    return query.replace("'", "''")
 
 
 def quote_table_name(table_name):


### PR DESCRIPTION
## Summary

Adds a small shared helper, `escape_sql`, to `clouds/oracle/common/test_utils/__init__.py`. It doubles single quotes inside Oracle string literals — used by tests that pass a SELECT query as a `VARCHAR2` argument to a stored procedure (e.g. all the Oracle data-enrichment procedures).

Centralising the helper avoids `.replace("'", "''")` sprinkled across every test file in the premium repo's data-enrichment tests.

## Shortcut

[sc-552688](https://app.shortcut.com/cartoteam/story/552688) — under epic [AT Release May 2026](https://app.shortcut.com/cartoteam/epic/549285).

## Companion PR (premium)

[CartoDB/analytics-toolbox#1070](https://github.com/CartoDB/analytics-toolbox/pull/1070) — `feat(ora|data): add data enrichment to Oracle`. That PR's tests import `escape_sql` from `test_utils`, so it depends on this PR being merged first.

## Test plan

- [ ] `make lint` passes in `clouds/oracle/`
- [ ] Premium Oracle data tests run green once both PRs are landed
