### PR TITLE
chore(sf|native_app): bump GET_MODULES_SQL_FROM_STAGE to Python 3.11 [sc-522383]

### DIFF
--- a/clouds/snowflake/native_app/SETUP_SCRIPT.sql
+++ b/clouds/snowflake/native_app/SETUP_SCRIPT.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE PROCEDURE @@SF_APP_SCHEMA@@.GET_MODULES_SQL_FROM_STAGE()
     returns string
     language python
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.11'
     packages = ('snowflake-snowpark-python')
     imports = (
         '/get_modules_sql_from_stage.py',


### PR DESCRIPTION
## Summary

- Bumps `RUNTIME_VERSION` from `3.9` → `3.11` on the `GET_MODULES_SQL_FROM_STAGE` native-app procedure in `clouds/snowflake/native_app/SETUP_SCRIPT.sql`.
- Python 3.9 was deprecated by Snowflake on 2025-10-05 (decommission 2026-04-30); 3.11 is recommended for new development.
- The procedure uses `snowflake-snowpark-python` without a version pin, so the runtime bump alone is sufficient — no behavioral changes.

Ticket: [sc-522383](https://app.shortcut.com/cartoteam/story/522383)

## Test plan

- [ ] CI green
- [ ] `make deploy-native-app-package` builds and deploys the native app successfully
- [ ] `make deploy-native-app` installs cleanly against a Snowflake account on the new runtime

## Related

A parallel PR in the premium repo (CartoDB/analytics-toolbox) bumps the matching Python procedures (`_SCORING_REGRESSION`, `_SCORING_FIRST_PC`/`_GET_FIRST_PC`, `_BUCKETIZE_JENKS`/`_SINGLE_KMEANS_CLUSTERING`, `_COMPRESS_GZIP`, premium `SETUP_SCRIPT.sql`, and the three `TIME_SERIES_CLUSTERING.*` files) to 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)