### PR TITLE
feat(sf,rs,pg,db,ora|h3,quadbin): add H3/QUADBIN_POLYFILL_TABLE procedures [sc-344469]

### DIFF
--- a/clouds/bigquery/modules/doc/h3/H3_POLYFILL_TABLE.md
+++ b/clouds/bigquery/modules/doc/h3/H3_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## H3_POLYFILL_TABLE (BETA)
+## H3_POLYFILL_TABLE
 
 ```sql:signature
 H3_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/bigquery/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/bigquery/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## QUADBIN_POLYFILL_TABLE (BETA)
+## QUADBIN_POLYFILL_TABLE
 
 ```sql:signature
 QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/bigquery/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/bigquery/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -25,7 +25,7 @@ AS """
 
     return 'CREATE TABLE `' + output_table + '` CLUSTER BY (quadbin) AS\\n' +
         'WITH __input AS (' + input_query + ')\\n' +
-        'SELECT quadbin, i.* FROM __input AS i,\\n' +
+        'SELECT quadbin, i.* EXCEPT (geom) FROM __input AS i,\\n' +
         'UNNEST(`@@BQ_DATASET@@.QUADBIN_POLYFILL_MODE`(geom,' + resolution + ',\\'' + mode + '\\')) AS quadbin;'
 """;
 

--- a/clouds/bigquery/modules/test/quadbin/QUADBIN_POLYFILL_TABLE.test.js
+++ b/clouds/bigquery/modules/test/quadbin/QUADBIN_POLYFILL_TABLE.test.js
@@ -12,6 +12,6 @@ test('QUADBIN_POLYFILL_TABLE should generate the correct query', async () => {
     expect(rows.length).toEqual(1);
     expect(rows[0].output).toEqual(`CREATE TABLE \`<project>.<dataset>.<output_table>\` CLUSTER BY (quadbin) AS
 WITH __input AS (SELECT geom, name, value FROM \`<project>.<dataset>.<table>\`)
-SELECT quadbin, i.* FROM __input AS i,
+SELECT quadbin, i.* EXCEPT (geom) FROM __input AS i,
 UNNEST(\`@@BQ_DATASET@@.QUADBIN_POLYFILL_MODE\`(geom,12,'center')) AS quadbin;`.replace(/@@BQ_DATASET@@/g, BQ_DATASET));
 });

--- a/clouds/databricks/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/databricks/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,11 @@
+from benchmark_utils import benchmark
+
+benchmark(
+    function='QUADBIN_POLYFILL_TABLE',
+    sql="""CALL @@DB_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+    '${input_query}',
+    ${resolution},
+    '${mode}',
+    '${output_table}'
+)""",
+)

--- a/clouds/databricks/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/databricks/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## QUADBIN_POLYFILL_TABLE (BETA)
+## QUADBIN_POLYFILL_TABLE
 
 ```sql:signature
 QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/databricks/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/databricks/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,0 +1,47 @@
+## QUADBIN_POLYFILL_TABLE (BETA)
+
+```sql:signature
+QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)
+```
+
+**Description**
+
+Creates a table with the quadbin cell indexes contained in the geographies of the input query at a requested resolution. All the attributes except the geography will be included in the output table.
+
+Unlike [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill), which returns the cells as an array, this procedure writes the result directly to a table. This avoids the array size limits that can be reached when polyfilling large geographies at high resolutions.
+
+**Input parameters**
+
+* `input_query`: `STRING` input data to polyfill. It must contain a column `geom` with the shape to cover. Additionally, other columns can be included.
+* `resolution`: `INT` level of detail. The value must be between 0 and 26.
+* `mode`: `STRING` `<center|contains|intersects>`. Accepted for forward compatibility. The native coverage produced by [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill) is used regardless of the value; mode-specific containment will be supported in a future release.
+* `output_table`: `STRING` qualified name of the output table, e.g. `<my-catalog>.<my-schema>.<my-output-table>`.
+
+**Output**
+
+The results are stored in the table named `<my-output-table>`, which contains the following columns:
+
+* `quadbin`: `BIGINT` the quadbin cell index.
+* The rest of columns included in `input_query` except `geom`.
+
+**Examples**
+
+```sql
+CALL carto.QUADBIN_POLYFILL_TABLE(
+  'SELECT ST_GEOMFROMTEXT(''POLYGON ((-3.71219873428345 40.413365349070865, -3.7144088745117 40.40965661286395, -3.70659828186035 40.409525904775634, -3.71219873428345 40.413365349070865))'', 4326) AS geom',
+  17, 'intersects',
+  '<my-catalog>.<my-schema>.<my-output-table>'
+);
+-- The table `<my-catalog>.<my-schema>.<my-output-table>` will be created
+-- with column: quadbin
+```
+
+```sql
+CALL carto.QUADBIN_POLYFILL_TABLE(
+  'SELECT geom, name, value FROM <my-catalog>.<my-schema>.<my-table>',
+  17, 'center',
+  '<my-catalog>.<my-schema>.<my-output-table>'
+);
+-- The table `<my-catalog>.<my-schema>.<my-output-table>` will be created
+-- with columns: quadbin, name, value
+```

--- a/clouds/databricks/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/databricks/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -1,0 +1,37 @@
+----------------------------
+-- Copyright (C) 2026 CARTO
+----------------------------
+
+CREATE OR REPLACE PROCEDURE @@DB_SCHEMA@@.QUADBIN_POLYFILL_TABLE
+(
+    input_query STRING,
+    resolution INT,
+    mode STRING,
+    output_table STRING
+)
+SQL SECURITY INVOKER
+BEGIN
+    -- NOTE: the `mode` parameter is accepted for forward compatibility. There
+    -- is no mode-aware QUADBIN_POLYFILL yet, so the native coverage produced by
+    -- QUADBIN_POLYFILL is used regardless of the requested `mode`. Full
+    -- center/intersects/contains support will arrive with QUADBIN_POLYFILL_MODE.
+    EXECUTE IMMEDIATE FORMAT_STRING(
+        "CREATE OR REPLACE TABLE %s AS (
+            WITH __input AS (
+                %s
+            ),
+            __cells AS (
+                SELECT
+                    @@DB_SCHEMA@@.QUADBIN_POLYFILL(geom, %d) AS __quadbins,
+                    __input.* EXCEPT (geom)
+                FROM __input
+            )
+            SELECT __cell AS quadbin, __cells.* EXCEPT (__quadbins)
+            FROM __cells
+            LATERAL VIEW EXPLODE(__quadbins) t AS __cell
+        )",
+        output_table,
+        input_query,
+        resolution
+    );
+END;

--- a/clouds/databricks/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/databricks/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
@@ -3,7 +3,8 @@
 from test_utils import run_query
 
 
-OUTPUT_TABLE = '@@DB_SCHEMA@@.quadbin_polyfill_table_test'
+INPUT_TABLE = '@@DB_SCHEMA@@.quadbin_polyfill_table_input'
+OUTPUT_TABLE = '@@DB_SCHEMA@@.quadbin_polyfill_table_output'
 
 POLYGON_WKT = (
     'POLYGON ((-3.71219873428345 40.413365349070865,'
@@ -25,43 +26,42 @@ EXPECTED_CELLS = sorted(
 )
 
 
-def _call(input_query, resolution, mode):
-    escaped = input_query.replace("'", "''")
-    return (
-        f'CALL @@DB_SCHEMA@@.QUADBIN_POLYFILL_TABLE('
-        f"    '{escaped}', {resolution}, '{mode}', '{OUTPUT_TABLE}'"
-        f')'
-    )
+def _cleanup():
+    run_query(f'DROP TABLE IF EXISTS {INPUT_TABLE}')
+    run_query(f'DROP TABLE IF EXISTS {OUTPUT_TABLE}')
 
 
 def test_quadbin_polyfill_table_creates_cells():
     try:
         run_query(
-            _call(
-                f"SELECT ST_GEOMFROMTEXT('{POLYGON_WKT}', 4326) AS geom",
-                17,
-                'intersects',
-            )
+            f'CREATE OR REPLACE TABLE {INPUT_TABLE} AS'
+            f" SELECT ST_GEOMFROMTEXT('{POLYGON_WKT}', 4326) AS geom"
+        )
+        run_query(
+            f'CALL @@DB_SCHEMA@@.QUADBIN_POLYFILL_TABLE('
+            f"'SELECT geom FROM {INPUT_TABLE}', 17, 'intersects', '{OUTPUT_TABLE}')"
         )
         result = run_query(f'SELECT quadbin FROM {OUTPUT_TABLE} ORDER BY quadbin')
         cells = sorted(int(row[0]) for row in result)
         assert cells == EXPECTED_CELLS
     finally:
-        run_query(f'DROP TABLE IF EXISTS {OUTPUT_TABLE}')
+        _cleanup()
 
 
 def test_quadbin_polyfill_table_preserves_columns():
     try:
         run_query(
-            _call(
-                f"SELECT ST_GEOMFROMTEXT('{POLYGON_WKT}', 4326) AS geom," ' 42 AS val',
-                17,
-                'intersects',
-            )
+            f'CREATE OR REPLACE TABLE {INPUT_TABLE} AS'
+            f" SELECT ST_GEOMFROMTEXT('{POLYGON_WKT}', 4326) AS geom, 42 AS val"
+        )
+        run_query(
+            f'CALL @@DB_SCHEMA@@.QUADBIN_POLYFILL_TABLE('
+            f"'SELECT geom, val FROM {INPUT_TABLE}', 17, 'intersects',"
+            f" '{OUTPUT_TABLE}')"
         )
         result = run_query(f'SELECT quadbin, val FROM {OUTPUT_TABLE} ORDER BY quadbin')
         cells = sorted(int(row[0]) for row in result)
         assert cells == EXPECTED_CELLS
         assert all(int(row[1]) == 42 for row in result)
     finally:
-        run_query(f'DROP TABLE IF EXISTS {OUTPUT_TABLE}')
+        _cleanup()

--- a/clouds/databricks/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/databricks/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, CARTO
+
+from test_utils import run_query
+
+
+OUTPUT_TABLE = '@@DB_SCHEMA@@.quadbin_polyfill_table_test'
+
+POLYGON_WKT = (
+    'POLYGON ((-3.71219873428345 40.413365349070865,'
+    '-3.7144088745117 40.40965661286395,'
+    '-3.70659828186035 40.409525904775634,'
+    '-3.71219873428345 40.413365349070865))'
+)
+
+# Expected quadbin coverage of the test polygon at resolution 17.
+EXPECTED_CELLS = sorted(
+    [
+        5265786693153193983,
+        5265786693163941887,
+        5265786693164204031,
+        5265786693164466175,
+        5265786693164728319,
+        5265786693165514751,
+    ]
+)
+
+
+def _call(input_query, resolution, mode):
+    escaped = input_query.replace("'", "''")
+    return (
+        f'CALL @@DB_SCHEMA@@.QUADBIN_POLYFILL_TABLE('
+        f"    '{escaped}', {resolution}, '{mode}', '{OUTPUT_TABLE}'"
+        f')'
+    )
+
+
+def test_quadbin_polyfill_table_creates_cells():
+    try:
+        run_query(
+            _call(
+                f"SELECT ST_GEOMFROMTEXT('{POLYGON_WKT}', 4326) AS geom",
+                17,
+                'intersects',
+            )
+        )
+        result = run_query(f'SELECT quadbin FROM {OUTPUT_TABLE} ORDER BY quadbin')
+        cells = sorted(int(row[0]) for row in result)
+        assert cells == EXPECTED_CELLS
+    finally:
+        run_query(f'DROP TABLE IF EXISTS {OUTPUT_TABLE}')
+
+
+def test_quadbin_polyfill_table_preserves_columns():
+    try:
+        run_query(
+            _call(
+                f"SELECT ST_GEOMFROMTEXT('{POLYGON_WKT}', 4326) AS geom," ' 42 AS val',
+                17,
+                'intersects',
+            )
+        )
+        result = run_query(f'SELECT quadbin, val FROM {OUTPUT_TABLE} ORDER BY quadbin')
+        cells = sorted(int(row[0]) for row in result)
+        assert cells == EXPECTED_CELLS
+        assert all(int(row[1]) == 42 for row in result)
+    finally:
+        run_query(f'DROP TABLE IF EXISTS {OUTPUT_TABLE}')

--- a/clouds/oracle/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/oracle/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,11 @@
+from benchmark_utils import benchmark
+
+benchmark(
+    function='QUADBIN_POLYFILL_TABLE',
+    sql="""CALL @@ORA_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+    '${input_query}',
+    ${resolution},
+    '${mode}',
+    '${output_table}'
+)""",
+)

--- a/clouds/oracle/modules/doc/h3/H3_POLYFILL_TABLE.md
+++ b/clouds/oracle/modules/doc/h3/H3_POLYFILL_TABLE.md
@@ -28,7 +28,7 @@ Invalid `polyfill_mode`, `resolution` outside `0..15`, or `NULL` arguments cause
 None — creates the named table as a side effect. The output table has columns:
 
 * `h3` `VARCHAR2(16)` — the polyfill cell.
-* every other column produced by `input_query`.
+* every other column produced by `input_query` except `geom`.
 
 **Example**
 

--- a/clouds/oracle/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/oracle/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## QUADBIN_POLYFILL_TABLE (BETA)
+## QUADBIN_POLYFILL_TABLE
 
 ```sql:signature
 QUADBIN_POLYFILL_TABLE(input_query, resolution, polyfill_mode, output_table)

--- a/clouds/oracle/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/oracle/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -24,7 +24,7 @@ Invalid `polyfill_mode`, `resolution` outside `0..26`, or `NULL` arguments cause
 None — creates the named table as a side effect. The output table has columns:
 
 * `quadbin` `NUMBER` — the polyfill cell.
-* every other column produced by `input_query`.
+* every other column produced by `input_query` except `geom`.
 
 **Example**
 

--- a/clouds/oracle/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/oracle/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,0 +1,49 @@
+## QUADBIN_POLYFILL_TABLE (BETA)
+
+```sql:signature
+QUADBIN_POLYFILL_TABLE(input_query, resolution, polyfill_mode, output_table)
+```
+
+**Description**
+
+Materializes the quadbin polyfill of every row in `input_query` into a new table. The resulting table joins each input row with the polyfill cells of its `geom` column, preserving every other column the input query exposes.
+
+This is the procedural form of [QUADBIN_POLYFILL](quadbin#quadbin_polyfill). Unlike the function, which returns the cells as a collection, this procedure writes the result directly to a table, avoiding the collection/array size limits that can be reached when polyfilling large geographies at high resolutions.
+
+Invalid `polyfill_mode`, `resolution` outside `0..26`, or `NULL` arguments cause the procedure to silently no-op (output table is not created).
+
+**Input parameters**
+
+* `input_query`: `VARCHAR2` SELECT statement; must expose a column named `geom` of type `SDO_GEOMETRY`. Any other columns are passed through to the output table.
+* `resolution`: `NUMBER` quadbin resolution (level of detail) between 0 and 26.
+* `polyfill_mode`: `VARCHAR2` `'center'`, `'intersects'`, or `'contains'`. Accepted for forward compatibility. (Named `polyfill_mode` rather than `mode` because `mode` is a reserved word in Oracle PL/SQL.) The native coverage produced by [QUADBIN_POLYFILL](quadbin#quadbin_polyfill) is used regardless of the value; mode-specific containment will be supported in a future release.
+* `output_table`: `VARCHAR2` fully-qualified name of the table to create. Sanitized via `DBMS_ASSERT.QUALIFIED_SQL_NAME`.
+
+**Return type**
+
+None — creates the named table as a side effect. The output table has columns:
+
+* `quadbin` `NUMBER` — the polyfill cell.
+* every other column produced by `input_query`.
+
+**Example**
+
+```sql
+BEGIN
+    carto.QUADBIN_POLYFILL_TABLE(
+        'SELECT SDO_UTIL.FROM_WKTGEOMETRY(''POLYGON ((-3.71219873428345 40.413365349070865, -3.7144088745117 40.40965661286395, -3.70659828186035 40.409525904775634, -3.71219873428345 40.413365349070865))'') AS geom FROM DUAL',
+        17,
+        'intersects',
+        '<my-schema>.<my-output-table>'
+    );
+END;
+/
+
+SELECT quadbin FROM <my-schema>.<my-output-table> ORDER BY quadbin;
+-- 5265786693153193983
+-- 5265786693163941887
+-- 5265786693164204031
+-- 5265786693164466175
+-- 5265786693164728319
+-- 5265786693165514751
+```

--- a/clouds/oracle/modules/sql/h3/H3_POLYFILL_TABLE.sql
+++ b/clouds/oracle/modules/sql/h3/H3_POLYFILL_TABLE.sql
@@ -16,7 +16,6 @@ IS
     v_mode VARCHAR2(20);
     v_res PLS_INTEGER;
     v_sql CLOB;
-    v_schema VARCHAR2(128);
     v_safe_table VARCHAR2(257);
 BEGIN
     -- NULL-on-invalid: silently no-op for invalid mode/resolution/inputs.
@@ -38,25 +37,18 @@ BEGIN
     -- Sanitize the output identifier (rejects malicious table names)
     v_safe_table := DBMS_ASSERT.QUALIFIED_SQL_NAME(output_table);
 
-    -- Resolve schema for the pipelined function reference
-    IF INSTR(v_safe_table, '.') > 0 THEN
-        v_schema := SUBSTR(v_safe_table, 1, INSTR(v_safe_table, '.') - 1);
-    ELSE
-        v_schema := SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA');
-    END IF;
-
     -- CTAS that consumes H3_POLYFILL_MODE as a pipelined nested table.
     -- The input_query must expose a column named GEOM of type SDO_GEOMETRY.
     -- Mode and resolution can't be bound as parameters here — Oracle
     -- raises ORA-22905 when bind variables appear inside a correlated
     -- TABLE() expression in a CTAS. They are safe to inline because we
     -- validated v_mode against a fixed allowlist and TRUNC'd v_res into
-    -- a small integer above. The output table name and schema are
-    -- validated identifiers (DBMS_ASSERT.QUALIFIED_SQL_NAME).
+    -- a small integer above. The output table name is a validated identifier
+    -- (DBMS_ASSERT.QUALIFIED_SQL_NAME); H3_POLYFILL_MODE lives in @@ORA_SCHEMA@@.
     v_sql := 'CREATE TABLE ' || v_safe_table || ' AS
         SELECT t.COLUMN_VALUE AS h3, i.*
           FROM (' || input_query || ') i,
-               TABLE(' || v_schema || '.H3_POLYFILL_MODE(
+               TABLE(@@ORA_SCHEMA@@.H3_POLYFILL_MODE(
                    i.geom, ' || v_res || ', ''' || v_mode || '''
                )) t';
 

--- a/clouds/oracle/modules/sql/h3/H3_POLYFILL_TABLE.sql
+++ b/clouds/oracle/modules/sql/h3/H3_POLYFILL_TABLE.sql
@@ -61,6 +61,9 @@ BEGIN
                )) t';
 
     EXECUTE IMMEDIATE v_sql;
+    -- The input GEOM is carried through by i.* above; drop it so the output
+    -- holds only the H3 index plus the remaining input columns.
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || v_safe_table || ' DROP COLUMN geom';
     COMMIT;
 
 EXCEPTION

--- a/clouds/oracle/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/oracle/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -16,7 +16,6 @@ IS
     v_mode VARCHAR2(20);
     v_res PLS_INTEGER;
     v_sql CLOB;
-    v_schema VARCHAR2(128);
     v_safe_table VARCHAR2(257);
 BEGIN
     -- NULL-on-invalid: silently no-op for invalid mode/resolution/inputs.
@@ -44,24 +43,17 @@ BEGIN
     -- Sanitize the output identifier (rejects malicious table names)
     v_safe_table := DBMS_ASSERT.QUALIFIED_SQL_NAME(output_table);
 
-    -- Resolve schema for the pipelined function reference
-    IF INSTR(v_safe_table, '.') > 0 THEN
-        v_schema := SUBSTR(v_safe_table, 1, INSTR(v_safe_table, '.') - 1);
-    ELSE
-        v_schema := SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA');
-    END IF;
-
     -- CTAS that consumes QUADBIN_POLYFILL as a pipelined nested table.
     -- The input_query must expose a column named GEOM of type SDO_GEOMETRY.
     -- The resolution can't be bound as a parameter here — Oracle raises
     -- ORA-22905 when bind variables appear inside a correlated TABLE()
     -- expression in a CTAS. It is safe to inline because it was TRUNC'd into
-    -- a small integer above. The output table name and schema are validated
-    -- identifiers (DBMS_ASSERT.QUALIFIED_SQL_NAME).
+    -- a small integer above. The output table name is a validated identifier
+    -- (DBMS_ASSERT.QUALIFIED_SQL_NAME); QUADBIN_POLYFILL lives in @@ORA_SCHEMA@@.
     v_sql := 'CREATE TABLE ' || v_safe_table || ' AS
         SELECT t.COLUMN_VALUE AS quadbin, i.*
           FROM (' || input_query || ') i,
-               TABLE(' || v_schema || '.QUADBIN_POLYFILL(
+               TABLE(@@ORA_SCHEMA@@.QUADBIN_POLYFILL(
                    i.geom, ' || v_res || '
                )) t';
 

--- a/clouds/oracle/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/oracle/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -66,6 +66,9 @@ BEGIN
                )) t';
 
     EXECUTE IMMEDIATE v_sql;
+    -- The input GEOM is carried through by i.* above; drop it so the output
+    -- holds only the quadbin index plus the remaining input columns.
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || v_safe_table || ' DROP COLUMN geom';
     COMMIT;
 
 EXCEPTION

--- a/clouds/oracle/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/oracle/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -1,0 +1,75 @@
+----------------------------
+-- Copyright (C) 2026 CARTO
+----------------------------
+
+CREATE OR REPLACE PROCEDURE @@ORA_SCHEMA@@.QUADBIN_POLYFILL_TABLE
+(
+    input_query VARCHAR2,
+    resolution NUMBER,
+    polyfill_mode VARCHAR2,
+    output_table VARCHAR2
+)
+IS
+    MIN_RESOLUTION CONSTANT PLS_INTEGER := 0;
+    MAX_RESOLUTION CONSTANT PLS_INTEGER := 26;
+
+    v_mode VARCHAR2(20);
+    v_res PLS_INTEGER;
+    v_sql CLOB;
+    v_schema VARCHAR2(128);
+    v_safe_table VARCHAR2(257);
+BEGIN
+    -- NULL-on-invalid: silently no-op for invalid mode/resolution/inputs.
+    IF input_query IS NULL OR resolution IS NULL
+       OR polyfill_mode IS NULL OR output_table IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- NOTE: `polyfill_mode` is accepted for forward compatibility. There is no
+    -- mode-aware QUADBIN_POLYFILL yet, so the native coverage produced by
+    -- QUADBIN_POLYFILL is used regardless of the requested mode. The value is
+    -- still validated against the allowlist so the contract matches the future
+    -- mode-aware implementation. Full center/intersects/contains support will
+    -- arrive with QUADBIN_POLYFILL_MODE.
+    v_mode := LOWER(polyfill_mode);
+    IF v_mode NOT IN ('center', 'intersects', 'contains') THEN
+        RETURN;
+    END IF;
+
+    v_res := TRUNC(resolution);
+    IF v_res < MIN_RESOLUTION OR v_res > MAX_RESOLUTION THEN
+        RETURN;
+    END IF;
+
+    -- Sanitize the output identifier (rejects malicious table names)
+    v_safe_table := DBMS_ASSERT.QUALIFIED_SQL_NAME(output_table);
+
+    -- Resolve schema for the pipelined function reference
+    IF INSTR(v_safe_table, '.') > 0 THEN
+        v_schema := SUBSTR(v_safe_table, 1, INSTR(v_safe_table, '.') - 1);
+    ELSE
+        v_schema := SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA');
+    END IF;
+
+    -- CTAS that consumes QUADBIN_POLYFILL as a pipelined nested table.
+    -- The input_query must expose a column named GEOM of type SDO_GEOMETRY.
+    -- The resolution can't be bound as a parameter here — Oracle raises
+    -- ORA-22905 when bind variables appear inside a correlated TABLE()
+    -- expression in a CTAS. It is safe to inline because it was TRUNC'd into
+    -- a small integer above. The output table name and schema are validated
+    -- identifiers (DBMS_ASSERT.QUALIFIED_SQL_NAME).
+    v_sql := 'CREATE TABLE ' || v_safe_table || ' AS
+        SELECT t.COLUMN_VALUE AS quadbin, i.*
+          FROM (' || input_query || ') i,
+               TABLE(' || v_schema || '.QUADBIN_POLYFILL(
+                   i.geom, ' || v_res || '
+               )) t';
+
+    EXECUTE IMMEDIATE v_sql;
+    COMMIT;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        NULL;
+END QUADBIN_POLYFILL_TABLE;
+/

--- a/clouds/oracle/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/oracle/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, CARTO
+import os
+from test_utils import drop_table, run_query
+
+
+SCHEMA = os.environ.get('ORA_SCHEMA', '')
+
+POLYGON_WKT = (
+    'POLYGON ((-3.71219873428345 40.413365349070865,'
+    '-3.7144088745117 40.40965661286395,'
+    '-3.70659828186035 40.409525904775634,'
+    '-3.71219873428345 40.413365349070865))'
+)
+
+# Expected quadbin coverage of the test polygon at resolution 17. The procedure
+# produces this set regardless of the requested mode until a mode-aware
+# QUADBIN_POLYFILL_MODE exists.
+EXPECTED_CELLS = [
+    5265786693153193983,
+    5265786693163941887,
+    5265786693164204031,
+    5265786693164466175,
+    5265786693164728319,
+    5265786693165514751,
+]
+
+
+def _call(input_query, resolution, mode, output_table):
+    """Build a CALL statement for QUADBIN_POLYFILL_TABLE."""
+    escaped_query = input_query.replace("'", "''")
+    return (
+        f'BEGIN @@ORA_SCHEMA@@.QUADBIN_POLYFILL_TABLE('
+        f"'{escaped_query}', {resolution}, '{mode}', "
+        f"'{output_table}'); END;"
+    )
+
+
+def test_quadbin_polyfill_table_creates_cells():
+    """The procedure materializes the quadbin coverage into a table."""
+    output_table = f'{SCHEMA}.TEST_QB_POLYFILL_ISECTS'
+    drop_table(output_table)
+    try:
+        run_query(
+            _call(
+                f"SELECT SDO_UTIL.FROM_WKTGEOMETRY('{POLYGON_WKT}') AS geom"
+                ' FROM DUAL',
+                17,
+                'intersects',
+                output_table,
+            )
+        )
+        result = run_query(f'SELECT quadbin FROM {output_table} ORDER BY quadbin')
+        cells = [int(r[0]) for r in result]
+        assert cells == sorted(EXPECTED_CELLS)
+    finally:
+        drop_table(output_table)
+
+
+def test_quadbin_polyfill_table_preserves_columns():
+    """Output table preserves all columns from input query."""
+    output_table = f'{SCHEMA}.TEST_QB_POLYFILL_COLS'
+    drop_table(output_table)
+    try:
+        run_query(
+            _call(
+                f"SELECT SDO_UTIL.FROM_WKTGEOMETRY('{POLYGON_WKT}') AS geom,"
+                ' 42 AS val FROM DUAL',
+                17,
+                'intersects',
+                output_table,
+            )
+        )
+        result = run_query(f'SELECT quadbin, val FROM {output_table} ORDER BY quadbin')
+        cells = [int(r[0]) for r in result]
+        assert cells == sorted(EXPECTED_CELLS)
+        assert all(r[1] == 42 for r in result)
+    finally:
+        drop_table(output_table)
+
+
+def test_quadbin_polyfill_table_invalid_mode():
+    """Invalid mode silently no-ops (NULL-on-invalid): output table not created."""
+    output_table = f'{SCHEMA}.TEST_QB_POLYFILL_BADMODE'
+    drop_table(output_table)
+    try:
+        run_query(
+            _call(
+                f"SELECT SDO_UTIL.FROM_WKTGEOMETRY('{POLYGON_WKT}') AS geom"
+                ' FROM DUAL',
+                17,
+                'invalid_mode',
+                output_table,
+            )
+        )
+        rows = run_query(
+            'SELECT COUNT(*) FROM USER_TABLES'
+            " WHERE TABLE_NAME = 'TEST_QB_POLYFILL_BADMODE'"
+        )
+        assert rows[0][0] == 0
+    finally:
+        drop_table(output_table)
+
+
+def test_quadbin_polyfill_table_invalid_resolution():
+    """Out-of-range resolution silently no-ops: output table not created."""
+    output_table = f'{SCHEMA}.TEST_QB_POLYFILL_BADRES'
+    drop_table(output_table)
+    try:
+        run_query(
+            _call(
+                f"SELECT SDO_UTIL.FROM_WKTGEOMETRY('{POLYGON_WKT}') AS geom"
+                ' FROM DUAL',
+                27,
+                'center',
+                output_table,
+            )
+        )
+        rows = run_query(
+            'SELECT COUNT(*) FROM USER_TABLES'
+            " WHERE TABLE_NAME = 'TEST_QB_POLYFILL_BADRES'"
+        )
+        assert rows[0][0] == 0
+    finally:
+        drop_table(output_table)
+
+
+def test_quadbin_polyfill_table_null_inputs():
+    """NULL inputs silently no-op: output table not created."""
+    output_table = f'{SCHEMA}.TEST_QB_POLYFILL_NULLIN'
+    drop_table(output_table)
+    try:
+        run_query(
+            _call(
+                f"SELECT SDO_UTIL.FROM_WKTGEOMETRY('{POLYGON_WKT}') AS geom"
+                ' FROM DUAL',
+                'NULL',
+                'center',
+                output_table,
+            )
+        )
+        rows = run_query(
+            'SELECT COUNT(*) FROM USER_TABLES'
+            " WHERE TABLE_NAME = 'TEST_QB_POLYFILL_NULLIN'"
+        )
+        assert rows[0][0] == 0
+    finally:
+        drop_table(output_table)

--- a/clouds/postgres/modules/benchmark/h3/benchmark_H3_POLYFILL_TABLE.py
+++ b/clouds/postgres/modules/benchmark/h3/benchmark_H3_POLYFILL_TABLE.py
@@ -1,0 +1,11 @@
+from benchmark_utils import benchmark
+
+benchmark(
+    function='H3_POLYFILL_TABLE',
+    sql="""CALL @@PG_SCHEMA@@.H3_POLYFILL_TABLE(
+    '${input_query}',
+    ${resolution},
+    '${mode}',
+    '${output_table}'
+)""",
+)

--- a/clouds/postgres/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/postgres/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,11 @@
+from benchmark_utils import benchmark
+
+benchmark(
+    function='QUADBIN_POLYFILL_TABLE',
+    sql="""CALL @@PG_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+    '${input_query}',
+    ${resolution},
+    '${mode}',
+    '${output_table}'
+)""",
+)

--- a/clouds/postgres/modules/doc/h3/H3_POLYFILL_TABLE.md
+++ b/clouds/postgres/modules/doc/h3/H3_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## H3_POLYFILL_TABLE (BETA)
+## H3_POLYFILL_TABLE
 
 ```sql:signature
 H3_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/postgres/modules/doc/h3/H3_POLYFILL_TABLE.md
+++ b/clouds/postgres/modules/doc/h3/H3_POLYFILL_TABLE.md
@@ -1,0 +1,50 @@
+## H3_POLYFILL_TABLE (BETA)
+
+```sql:signature
+H3_POLYFILL_TABLE(input_query, resolution, mode, output_table)
+```
+
+**Description**
+
+Creates a table with the H3 cell indexes contained in the geographies of the input query at a requested resolution. Containment is determined by the mode: center, intersects, contains. All the attributes except the geography will be included in the output table.
+
+Unlike [`H3_POLYFILL`](h3#h3_polyfill), which returns the cells as an array, this procedure writes the result directly to a table. This avoids the array size limits that can be reached when polyfilling large geographies at high resolutions.
+
+**Input parameters**
+
+* `input_query`: `TEXT` input data to polyfill. It must contain a column `geom` with the shape to cover. Additionally, other columns can be included.
+* `resolution`: `INT` number between 0 and 15 with the [H3 resolution](https://h3geo.org/docs/core-library/restable).
+* `mode`: `TEXT` `<center|contains|intersects>`.
+  * `center`: The center point of the H3 cell must be within the polygon.
+  * `contains`: The H3 cell must be fully contained within the polygon (least inclusive).
+  * `intersects`: The H3 cell intersects in any way with the polygon (most inclusive).
+* `output_table`: `TEXT` qualified name of the output table, e.g. `<my-schema>.<my-output-table>`.
+
+**Output**
+
+The results are stored in the table named `<my-output-table>`, which contains the following columns:
+
+* `h3`: `VARCHAR` the H3 cell index.
+* The rest of columns included in `input_query` except `geom`.
+
+**Examples**
+
+```sql
+CALL carto.H3_POLYFILL_TABLE(
+  'SELECT ST_GEOMFROMTEXT(''POLYGON ((-3.71219873428345 40.413365349070865, -3.7144088745117 40.40965661286395, -3.70659828186035 40.409525904775634, -3.71219873428345 40.413365349070865))'') AS geom',
+  9, 'intersects',
+  '<my-schema>.<my-output-table>'
+);
+-- The table `<my-schema>.<my-output-table>` will be created
+-- with column: h3
+```
+
+```sql
+CALL carto.H3_POLYFILL_TABLE(
+  'SELECT geom, name, value FROM <my-schema>.<my-table>',
+  9, 'center',
+  '<my-schema>.<my-output-table>'
+);
+-- The table `<my-schema>.<my-output-table>` will be created
+-- with columns: h3, name, value
+```

--- a/clouds/postgres/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/postgres/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,0 +1,50 @@
+## QUADBIN_POLYFILL_TABLE (BETA)
+
+```sql:signature
+QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)
+```
+
+**Description**
+
+Creates a table with the quadbin cell indexes contained in the geographies of the input query at a requested resolution. Containment is determined by the mode: center, intersects, contains. All the attributes except the geography will be included in the output table.
+
+Unlike [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill), which returns the cells as an array, this procedure writes the result directly to a table. This avoids the array size limits that can be reached when polyfilling large geographies at high resolutions.
+
+**Input parameters**
+
+* `input_query`: `TEXT` input data to polyfill. It must contain a column `geom` with the shape to cover. Additionally, other columns can be included.
+* `resolution`: `INT` level of detail. The value must be between 0 and 26.
+* `mode`: `TEXT`.
+  * `center` returns the indexes of the quadbin cells which centers intersect the input geography (polygon). The resulting quadbin set does not fully cover the input geography, however, this is **significantly faster** than the other modes. This mode is not compatible with points or lines. Equivalent to [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill).
+  * `intersects` returns the indexes of the quadbin cells that intersect the input geography. The resulting quadbin set will completely cover the input geography (point, line, polygon).
+  * `contains` returns the indexes of the quadbin cells that are entirely contained inside the input geography (polygon). This mode is not compatible with points or lines.
+* `output_table`: `TEXT` qualified name of the output table, e.g. `<my-schema>.<my-output-table>`.
+
+**Output**
+
+The results are stored in the table named `<my-output-table>`, which contains the following columns:
+
+* `quadbin`: `BIGINT` the quadbin cell index.
+* The rest of columns included in `input_query` except `geom`.
+
+**Examples**
+
+```sql
+CALL carto.QUADBIN_POLYFILL_TABLE(
+  'SELECT ST_GEOMFROMTEXT(''POLYGON ((-3.71219873428345 40.413365349070865, -3.7144088745117 40.40965661286395, -3.70659828186035 40.409525904775634, -3.71219873428345 40.413365349070865))'') AS geom',
+  17, 'intersects',
+  '<my-schema>.<my-output-table>'
+);
+-- The table `<my-schema>.<my-output-table>` will be created
+-- with column: quadbin
+```
+
+```sql
+CALL carto.QUADBIN_POLYFILL_TABLE(
+  'SELECT geom, name, value FROM <my-schema>.<my-table>',
+  17, 'center',
+  '<my-schema>.<my-output-table>'
+);
+-- The table `<my-schema>.<my-output-table>` will be created
+-- with columns: quadbin, name, value
+```

--- a/clouds/postgres/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/postgres/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## QUADBIN_POLYFILL_TABLE (BETA)
+## QUADBIN_POLYFILL_TABLE
 
 ```sql:signature
 QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/postgres/modules/sql/h3/H3_POLYFILL_TABLE.sql
+++ b/clouds/postgres/modules/sql/h3/H3_POLYFILL_TABLE.sql
@@ -12,7 +12,14 @@ LANGUAGE plpgsql
 AS $BODY$
 DECLARE
     extra_columns TEXT;
+    safe_output_table TEXT;
 BEGIN
+    -- Sanitize the output identifier: parse_ident validates each part (and
+    -- rejects injection attempts) and quote_ident re-quotes it safely.
+    SELECT STRING_AGG(QUOTE_IDENT(part), '.' ORDER BY ord)
+    INTO safe_output_table
+    FROM UNNEST(PARSE_IDENT(output_table)) WITH ORDINALITY AS t(part, ord);
+
     -- Materialize the input into a temp table so its columns can be
     -- introspected and every attribute except `geom` carried through into the
     -- output table.
@@ -28,14 +35,14 @@ BEGIN
     FROM information_schema.columns
     WHERE table_schema LIKE 'pg_temp%'
         AND table_name = '__h3_polyfill_table_input'
-        AND column_name <> 'geom';
+        AND column_name NOT IN ('geom', 'h3');
 
     EXECUTE FORMAT(
         'CREATE TABLE %s AS
         SELECT __cell AS h3%s
         FROM __h3_polyfill_table_input AS i,
             UNNEST(@@PG_SCHEMA@@.H3_POLYFILL(i.geom, %s, %L)) AS __cell',
-        output_table,
+        safe_output_table,
         CASE WHEN extra_columns IS NULL THEN '' ELSE ', ' || extra_columns END,
         resolution,
         mode

--- a/clouds/postgres/modules/sql/h3/H3_POLYFILL_TABLE.sql
+++ b/clouds/postgres/modules/sql/h3/H3_POLYFILL_TABLE.sql
@@ -11,7 +11,6 @@ CREATE OR REPLACE PROCEDURE @@PG_SCHEMA@@.H3_POLYFILL_TABLE(
 LANGUAGE plpgsql
 AS $BODY$
 DECLARE
-    extra_columns TEXT;
     safe_output_table TEXT;
 BEGIN
     -- Sanitize the output identifier: parse_ident validates each part (and
@@ -20,34 +19,18 @@ BEGIN
     INTO safe_output_table
     FROM UNNEST(PARSE_IDENT(output_table)) WITH ORDINALITY AS t(part, ord);
 
-    -- Materialize the input into a temp table so its columns can be
-    -- introspected and every attribute except `geom` carried through into the
-    -- output table.
-    DROP TABLE IF EXISTS __h3_polyfill_table_input;
-    EXECUTE FORMAT(
-        'CREATE TEMP TABLE __h3_polyfill_table_input AS %s', input_query
-    );
-
-    SELECT STRING_AGG(
-        'i.' || QUOTE_IDENT(column_name), ', ' ORDER BY ordinal_position
-    )
-    INTO extra_columns
-    FROM information_schema.columns
-    WHERE table_schema LIKE 'pg_temp%'
-        AND table_name = '__h3_polyfill_table_input'
-        AND column_name NOT IN ('geom', 'h3');
-
+    -- Every input column is carried through; `geom` is dropped from the
+    -- output afterwards.
     EXECUTE FORMAT(
         'CREATE TABLE %s AS
-        SELECT __cell AS h3%s
-        FROM __h3_polyfill_table_input AS i,
+        SELECT __cell AS h3, i.*
+        FROM (%s) AS i,
             UNNEST(@@PG_SCHEMA@@.H3_POLYFILL(i.geom, %s, %L)) AS __cell',
         safe_output_table,
-        CASE WHEN extra_columns IS NULL THEN '' ELSE ', ' || extra_columns END,
+        input_query,
         resolution,
         mode
     );
-
-    DROP TABLE IF EXISTS __h3_polyfill_table_input;
+    EXECUTE FORMAT('ALTER TABLE %s DROP COLUMN geom', safe_output_table);
 END;
 $BODY$;

--- a/clouds/postgres/modules/sql/h3/H3_POLYFILL_TABLE.sql
+++ b/clouds/postgres/modules/sql/h3/H3_POLYFILL_TABLE.sql
@@ -1,0 +1,46 @@
+----------------------------
+-- Copyright (C) 2026 CARTO
+----------------------------
+
+CREATE OR REPLACE PROCEDURE @@PG_SCHEMA@@.H3_POLYFILL_TABLE(
+    input_query TEXT,
+    resolution INT,
+    mode TEXT,
+    output_table TEXT
+)
+LANGUAGE plpgsql
+AS $BODY$
+DECLARE
+    extra_columns TEXT;
+BEGIN
+    -- Materialize the input into a temp table so its columns can be
+    -- introspected and every attribute except `geom` carried through into the
+    -- output table.
+    DROP TABLE IF EXISTS __h3_polyfill_table_input;
+    EXECUTE FORMAT(
+        'CREATE TEMP TABLE __h3_polyfill_table_input AS %s', input_query
+    );
+
+    SELECT STRING_AGG(
+        'i.' || QUOTE_IDENT(column_name), ', ' ORDER BY ordinal_position
+    )
+    INTO extra_columns
+    FROM information_schema.columns
+    WHERE table_schema LIKE 'pg_temp%'
+        AND table_name = '__h3_polyfill_table_input'
+        AND column_name <> 'geom';
+
+    EXECUTE FORMAT(
+        'CREATE TABLE %s AS
+        SELECT __cell AS h3%s
+        FROM __h3_polyfill_table_input AS i,
+            UNNEST(@@PG_SCHEMA@@.H3_POLYFILL(i.geom, %s, %L)) AS __cell',
+        output_table,
+        CASE WHEN extra_columns IS NULL THEN '' ELSE ', ' || extra_columns END,
+        resolution,
+        mode
+    );
+
+    DROP TABLE IF EXISTS __h3_polyfill_table_input;
+END;
+$BODY$;

--- a/clouds/postgres/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/postgres/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -12,7 +12,14 @@ LANGUAGE plpgsql
 AS $BODY$
 DECLARE
     extra_columns TEXT;
+    safe_output_table TEXT;
 BEGIN
+    -- Sanitize the output identifier: parse_ident validates each part (and
+    -- rejects injection attempts) and quote_ident re-quotes it safely.
+    SELECT STRING_AGG(QUOTE_IDENT(part), '.' ORDER BY ord)
+    INTO safe_output_table
+    FROM UNNEST(PARSE_IDENT(output_table)) WITH ORDINALITY AS t(part, ord);
+
     -- Materialize the input into a temp table so its columns can be
     -- introspected and every attribute except `geom` carried through into the
     -- output table.
@@ -28,14 +35,14 @@ BEGIN
     FROM information_schema.columns
     WHERE table_schema LIKE 'pg_temp%'
         AND table_name = '__quadbin_polyfill_table_input'
-        AND column_name <> 'geom';
+        AND column_name NOT IN ('geom', 'quadbin');
 
     EXECUTE FORMAT(
         'CREATE TABLE %s AS
         SELECT __cell AS quadbin%s
         FROM __quadbin_polyfill_table_input AS i,
             UNNEST(@@PG_SCHEMA@@.QUADBIN_POLYFILL(i.geom, %s, %L)) AS __cell',
-        output_table,
+        safe_output_table,
         CASE WHEN extra_columns IS NULL THEN '' ELSE ', ' || extra_columns END,
         resolution,
         mode

--- a/clouds/postgres/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/postgres/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -11,7 +11,6 @@ CREATE OR REPLACE PROCEDURE @@PG_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
 LANGUAGE plpgsql
 AS $BODY$
 DECLARE
-    extra_columns TEXT;
     safe_output_table TEXT;
 BEGIN
     -- Sanitize the output identifier: parse_ident validates each part (and
@@ -20,34 +19,18 @@ BEGIN
     INTO safe_output_table
     FROM UNNEST(PARSE_IDENT(output_table)) WITH ORDINALITY AS t(part, ord);
 
-    -- Materialize the input into a temp table so its columns can be
-    -- introspected and every attribute except `geom` carried through into the
-    -- output table.
-    DROP TABLE IF EXISTS __quadbin_polyfill_table_input;
-    EXECUTE FORMAT(
-        'CREATE TEMP TABLE __quadbin_polyfill_table_input AS %s', input_query
-    );
-
-    SELECT STRING_AGG(
-        'i.' || QUOTE_IDENT(column_name), ', ' ORDER BY ordinal_position
-    )
-    INTO extra_columns
-    FROM information_schema.columns
-    WHERE table_schema LIKE 'pg_temp%'
-        AND table_name = '__quadbin_polyfill_table_input'
-        AND column_name NOT IN ('geom', 'quadbin');
-
+    -- Every input column is carried through; `geom` is dropped from the
+    -- output afterwards.
     EXECUTE FORMAT(
         'CREATE TABLE %s AS
-        SELECT __cell AS quadbin%s
-        FROM __quadbin_polyfill_table_input AS i,
+        SELECT __cell AS quadbin, i.*
+        FROM (%s) AS i,
             UNNEST(@@PG_SCHEMA@@.QUADBIN_POLYFILL(i.geom, %s, %L)) AS __cell',
         safe_output_table,
-        CASE WHEN extra_columns IS NULL THEN '' ELSE ', ' || extra_columns END,
+        input_query,
         resolution,
         mode
     );
-
-    DROP TABLE IF EXISTS __quadbin_polyfill_table_input;
+    EXECUTE FORMAT('ALTER TABLE %s DROP COLUMN geom', safe_output_table);
 END;
 $BODY$;

--- a/clouds/postgres/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/postgres/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -1,0 +1,46 @@
+----------------------------
+-- Copyright (C) 2026 CARTO
+----------------------------
+
+CREATE OR REPLACE PROCEDURE @@PG_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+    input_query TEXT,
+    resolution INT,
+    mode TEXT,
+    output_table TEXT
+)
+LANGUAGE plpgsql
+AS $BODY$
+DECLARE
+    extra_columns TEXT;
+BEGIN
+    -- Materialize the input into a temp table so its columns can be
+    -- introspected and every attribute except `geom` carried through into the
+    -- output table.
+    DROP TABLE IF EXISTS __quadbin_polyfill_table_input;
+    EXECUTE FORMAT(
+        'CREATE TEMP TABLE __quadbin_polyfill_table_input AS %s', input_query
+    );
+
+    SELECT STRING_AGG(
+        'i.' || QUOTE_IDENT(column_name), ', ' ORDER BY ordinal_position
+    )
+    INTO extra_columns
+    FROM information_schema.columns
+    WHERE table_schema LIKE 'pg_temp%'
+        AND table_name = '__quadbin_polyfill_table_input'
+        AND column_name <> 'geom';
+
+    EXECUTE FORMAT(
+        'CREATE TABLE %s AS
+        SELECT __cell AS quadbin%s
+        FROM __quadbin_polyfill_table_input AS i,
+            UNNEST(@@PG_SCHEMA@@.QUADBIN_POLYFILL(i.geom, %s, %L)) AS __cell',
+        output_table,
+        CASE WHEN extra_columns IS NULL THEN '' ELSE ', ' || extra_columns END,
+        resolution,
+        mode
+    );
+
+    DROP TABLE IF EXISTS __quadbin_polyfill_table_input;
+END;
+$BODY$;

--- a/clouds/postgres/modules/test/h3/test_H3_POLYFILL_TABLE.py
+++ b/clouds/postgres/modules/test/h3/test_H3_POLYFILL_TABLE.py
@@ -1,0 +1,48 @@
+# flake8: noqa
+from test_utils import run_query, run_query_without_result, drop_table
+
+polygon = 'POLYGON ((-3.71219873428345 40.413365349070865,-3.7144088745117 40.40965661286395,-3.70659828186035 40.409525904775634,-3.71219873428345 40.413365349070865))'
+
+
+def test_h3_polyfill_table_only_index():
+    drop_table('h3_polyfill_table_test')
+    run_query_without_result(
+        f"""
+        CALL @@PG_SCHEMA@@.H3_POLYFILL_TABLE(
+            'SELECT ST_GEOMFROMTEXT(''{polygon}'') AS geom',
+            9, 'intersects',
+            '@@PG_SCHEMA@@.h3_polyfill_table_test')
+        """
+    )
+    result = run_query(
+        'SELECT h3 FROM @@PG_SCHEMA@@.h3_polyfill_table_test ORDER BY h3'
+    )
+    cells = [row[0] for row in result]
+    assert sorted(cells) == sorted(
+        [
+            '89390cb1b4fffff',
+            '89390ca3497ffff',
+            '89390ca34b3ffff',
+            '89390cb1b4bffff',
+            '89390ca3487ffff',
+            '89390cb1b5bffff',
+        ]
+    )
+    drop_table('h3_polyfill_table_test')
+
+
+def test_h3_polyfill_table_extra_columns():
+    drop_table('h3_polyfill_table_test')
+    run_query_without_result(
+        f"""
+        CALL @@PG_SCHEMA@@.H3_POLYFILL_TABLE(
+            'SELECT ST_GEOMFROMTEXT(''{polygon}'') AS geom, 42 AS value',
+            9, 'center',
+            '@@PG_SCHEMA@@.h3_polyfill_table_test')
+        """
+    )
+    result = run_query(
+        'SELECT h3, value FROM @@PG_SCHEMA@@.h3_polyfill_table_test ORDER BY h3'
+    )
+    assert result == [('89390cb1b4bffff', 42)]
+    drop_table('h3_polyfill_table_test')

--- a/clouds/postgres/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/postgres/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,53 @@
+# flake8: noqa
+from test_utils import run_query, run_query_without_result, drop_table
+
+polygon = 'POLYGON ((-3.71219873428345 40.413365349070865,-3.7144088745117 40.40965661286395,-3.70659828186035 40.409525904775634,-3.71219873428345 40.413365349070865))'
+
+
+def test_quadbin_polyfill_table_only_index():
+    drop_table('quadbin_polyfill_table_test')
+    run_query_without_result(
+        f"""
+        CALL @@PG_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+            'SELECT ST_GEOMFROMTEXT(''{polygon}'') AS geom',
+            17, 'intersects',
+            '@@PG_SCHEMA@@.quadbin_polyfill_table_test')
+        """
+    )
+    result = run_query(
+        'SELECT quadbin FROM @@PG_SCHEMA@@.quadbin_polyfill_table_test ORDER BY quadbin'
+    )
+    cells = [row[0] for row in result]
+    assert sorted(cells) == sorted(
+        [
+            5265786693153193983,
+            5265786693163941887,
+            5265786693164204031,
+            5265786693164466175,
+            5265786693164728319,
+            5265786693165514751,
+        ]
+    )
+    drop_table('quadbin_polyfill_table_test')
+
+
+def test_quadbin_polyfill_table_extra_columns():
+    drop_table('quadbin_polyfill_table_test')
+    run_query_without_result(
+        f"""
+        CALL @@PG_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+            'SELECT ST_GEOMFROMTEXT(''{polygon}'') AS geom, 42 AS value',
+            17, 'center',
+            '@@PG_SCHEMA@@.quadbin_polyfill_table_test')
+        """
+    )
+    result = run_query(
+        'SELECT quadbin, value FROM @@PG_SCHEMA@@.quadbin_polyfill_table_test '
+        'ORDER BY quadbin'
+    )
+    assert result == [
+        (5265786693163941887, 42),
+        (5265786693164466175, 42),
+        (5265786693164728319, 42),
+    ]
+    drop_table('quadbin_polyfill_table_test')

--- a/clouds/redshift/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/redshift/modules/benchmark/quadbin/benchmark_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,11 @@
+from benchmark_utils import benchmark
+
+benchmark(
+    function='QUADBIN_POLYFILL_TABLE',
+    sql="""CALL @@RS_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+    '${input_query}',
+    ${resolution},
+    '${mode}',
+    '${output_table}'
+)""",
+)

--- a/clouds/redshift/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/redshift/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## QUADBIN_POLYFILL_TABLE (BETA)
+## QUADBIN_POLYFILL_TABLE
 
 ```sql:signature
 QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/redshift/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/redshift/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,0 +1,41 @@
+## QUADBIN_POLYFILL_TABLE (BETA)
+
+```sql:signature
+QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)
+```
+
+**Description**
+
+Creates a table with the quadbin cell indexes contained in the geographies of the input query at a requested resolution. All the attributes except the geography are included in the output table.
+
+Unlike [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill), which returns the cells as an array, this procedure writes the result directly to a table.
+
+**Input parameters**
+
+* `input_query`: `VARCHAR(MAX)` SELECT statement to polyfill. It must contain a column `geom` with the shape to cover. Additionally, other columns can be included.
+* `resolution`: `INT` level of detail. The value must be between 0 and 26.
+* `mode`: `VARCHAR(MAX)` `<center|contains|intersects>`. Accepted for forward compatibility. The native coverage produced by [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill) is used regardless of the value; mode-specific containment will be supported in a future release.
+* `output_table`: `VARCHAR(MAX)` qualified name of the output table, e.g. `<my-schema>.<my-output-table>`.
+
+**Return type**
+
+None — creates the named table as a side effect. The output table has columns:
+
+* `quadbin`: `BIGINT` the quadbin cell index.
+* The rest of columns included in `input_query` except `geom`.
+
+**Note**
+
+`QUADBIN_POLYFILL` is resolved through the AT Gateway, so the polyfill of each input geometry is bounded by the gateway response size. Very large single-geometry polyfills at high resolutions may exceed that bound.
+
+**Example**
+
+```sql
+CALL carto.QUADBIN_POLYFILL_TABLE(
+  'SELECT geom FROM <my-schema>.<my-table>',
+  11, 'center',
+  '<my-schema>.<my-output-table>'
+);
+-- The table `<my-schema>.<my-output-table>` will be created
+-- with column: quadbin
+```

--- a/clouds/redshift/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/redshift/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -11,51 +11,55 @@ CREATE OR REPLACE PROCEDURE @@RS_SCHEMA@@.QUADBIN_POLYFILL_TABLE
 )
 AS $$
 DECLARE
-    passthrough_inner VARCHAR(MAX);
-    passthrough_outer VARCHAR(MAX);
     output_first VARCHAR(MAX);
     output_second VARCHAR(MAX);
     output_third VARCHAR(MAX);
     output_fourth VARCHAR(MAX);
+    safe_output_table VARCHAR(MAX);
 BEGIN
     -- The `mode` parameter is accepted for forward compatibility. There is no
     -- mode-aware QUADBIN_POLYFILL yet, so the native coverage produced by
     -- QUADBIN_POLYFILL is used regardless of the requested `mode`. Full
     -- center/intersects/contains support will arrive with QUADBIN_POLYFILL_MODE.
 
-    -- Validate the output table name
-    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 1)' INTO output_first;
-    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 2)' INTO output_second;
-    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 3)' INTO output_third;
-    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 4)' INTO output_fourth;
+    -- Validate and safely quote the output table name. QUOTE_LITERAL guards
+    -- the validation queries and QUOTE_IDENT guards the DDL below, so the
+    -- output_table value can never inject SQL.
+    EXECUTE 'SELECT split_part(' || QUOTE_LITERAL(output_table) || ', ''.'', 1)'
+        INTO output_first;
+    EXECUTE 'SELECT split_part(' || QUOTE_LITERAL(output_table) || ', ''.'', 2)'
+        INTO output_second;
+    EXECUTE 'SELECT split_part(' || QUOTE_LITERAL(output_table) || ', ''.'', 3)'
+        INTO output_third;
+    EXECUTE 'SELECT split_part(' || QUOTE_LITERAL(output_table) || ', ''.'', 4)'
+        INTO output_fourth;
     IF output_first = '' OR output_second = '' OR output_fourth != ''
     THEN
-        RAISE EXCEPTION 'Invalid output table name. It must have the form [DATABASE.]SCHEMA.TABLE';
+        RAISE EXCEPTION
+            'Invalid output table name. It must have the form [DATABASE.]SCHEMA.TABLE';
+    END IF;
+    IF output_third = ''
+    THEN
+        safe_output_table := QUOTE_IDENT(output_first)
+            || '.' || QUOTE_IDENT(output_second);
+    ELSE
+        safe_output_table := QUOTE_IDENT(output_first)
+            || '.' || QUOTE_IDENT(output_second)
+            || '.' || QUOTE_IDENT(output_third);
     END IF;
 
-    -- Materialize the input so its columns can be introspected and every
-    -- attribute except `geom` carried through into the output table.
-    EXECUTE 'DROP TABLE IF EXISTS __quadbin_polyfill_input';
-    EXECUTE 'CREATE TEMP TABLE __quadbin_polyfill_input AS ' || input_query;
-
-    SELECT
-        LISTAGG(QUOTE_IDENT("column"), ', ') WITHIN GROUP (ORDER BY "column"),
-        LISTAGG('p.' || QUOTE_IDENT("column"), ', ') WITHIN GROUP (ORDER BY "column")
-    INTO passthrough_inner, passthrough_outer
-    FROM pg_table_def
-    WHERE tablename = '__quadbin_polyfill_input'
-        AND "column" <> 'geom';
-
-    -- Unnest the QUADBIN_POLYFILL SUPER array into one row per cell. The array
-    -- is produced as a subquery column, then navigated with PartiQL.
-    EXECUTE 'CREATE TABLE ' || output_table || ' AS
-        SELECT __cell::BIGINT AS quadbin' || NVL(', ' || passthrough_outer, '') || '
+    -- Unnest the QUADBIN_POLYFILL SUPER array into one row per cell, carrying
+    -- through every input column. Redshift has no `SELECT * EXCEPT`, so the
+    -- helper array column and `geom` are dropped from the output afterwards.
+    EXECUTE 'CREATE TABLE ' || safe_output_table || ' AS
+        SELECT __cell::BIGINT AS quadbin, p.*
         FROM (
-            SELECT @@RS_SCHEMA@@.QUADBIN_POLYFILL(geom, ' || resolution || ') AS __quadbins'
-            || NVL(', ' || passthrough_inner, '') || '
-            FROM __quadbin_polyfill_input
+            SELECT *,
+                @@RS_SCHEMA@@.QUADBIN_POLYFILL(geom, ' || resolution || ')
+                    AS __quadbins
+            FROM (' || input_query || ') AS __input
         ) AS p, p.__quadbins AS __cell';
-
-    EXECUTE 'DROP TABLE IF EXISTS __quadbin_polyfill_input';
+    EXECUTE 'ALTER TABLE ' || safe_output_table || ' DROP COLUMN __quadbins';
+    EXECUTE 'ALTER TABLE ' || safe_output_table || ' DROP COLUMN geom';
 END;
 $$ LANGUAGE plpgsql;

--- a/clouds/redshift/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/redshift/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -1,0 +1,61 @@
+--------------------------------
+-- Copyright (C) 2026 CARTO
+--------------------------------
+
+CREATE OR REPLACE PROCEDURE @@RS_SCHEMA@@.QUADBIN_POLYFILL_TABLE
+(
+    input_query VARCHAR(MAX),
+    resolution INT,
+    mode VARCHAR(MAX),
+    output_table VARCHAR(MAX)
+)
+AS $$
+DECLARE
+    passthrough_inner VARCHAR(MAX);
+    passthrough_outer VARCHAR(MAX);
+    output_first VARCHAR(MAX);
+    output_second VARCHAR(MAX);
+    output_third VARCHAR(MAX);
+    output_fourth VARCHAR(MAX);
+BEGIN
+    -- The `mode` parameter is accepted for forward compatibility. There is no
+    -- mode-aware QUADBIN_POLYFILL yet, so the native coverage produced by
+    -- QUADBIN_POLYFILL is used regardless of the requested `mode`. Full
+    -- center/intersects/contains support will arrive with QUADBIN_POLYFILL_MODE.
+
+    -- Validate the output table name
+    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 1)' INTO output_first;
+    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 2)' INTO output_second;
+    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 3)' INTO output_third;
+    EXECUTE 'SELECT split_part(''' || output_table || ''', ''.'', 4)' INTO output_fourth;
+    IF output_first = '' OR output_second = '' OR output_fourth != ''
+    THEN
+        RAISE EXCEPTION 'Invalid output table name. It must have the form [DATABASE.]SCHEMA.TABLE';
+    END IF;
+
+    -- Materialize the input so its columns can be introspected and every
+    -- attribute except `geom` carried through into the output table.
+    EXECUTE 'DROP TABLE IF EXISTS __quadbin_polyfill_input';
+    EXECUTE 'CREATE TEMP TABLE __quadbin_polyfill_input AS ' || input_query;
+
+    SELECT
+        LISTAGG(QUOTE_IDENT("column"), ', ') WITHIN GROUP (ORDER BY "column"),
+        LISTAGG('p.' || QUOTE_IDENT("column"), ', ') WITHIN GROUP (ORDER BY "column")
+    INTO passthrough_inner, passthrough_outer
+    FROM pg_table_def
+    WHERE tablename = '__quadbin_polyfill_input'
+        AND "column" <> 'geom';
+
+    -- Unnest the QUADBIN_POLYFILL SUPER array into one row per cell. The array
+    -- is produced as a subquery column, then navigated with PartiQL.
+    EXECUTE 'CREATE TABLE ' || output_table || ' AS
+        SELECT __cell::BIGINT AS quadbin' || NVL(', ' || passthrough_outer, '') || '
+        FROM (
+            SELECT @@RS_SCHEMA@@.QUADBIN_POLYFILL(geom, ' || resolution || ') AS __quadbins'
+            || NVL(', ' || passthrough_inner, '') || '
+            FROM __quadbin_polyfill_input
+        ) AS p, p.__quadbins AS __cell';
+
+    EXECUTE 'DROP TABLE IF EXISTS __quadbin_polyfill_input';
+END;
+$$ LANGUAGE plpgsql;

--- a/clouds/redshift/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/redshift/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
@@ -28,7 +28,7 @@ def test_quadbin_polyfill_table():
             'drop table if exists @@RS_SCHEMA@@.quadbin_polyfill_table_output',
             'create table @@RS_SCHEMA@@.quadbin_polyfill_table_input(geom GEOMETRY)',
             f"""insert into @@RS_SCHEMA@@.quadbin_polyfill_table_input
-                values (ST_GeomFromText('{POLYGON}'))""",
+                values (ST_GeomFromText('{POLYGON}', 4326))""",
             """call @@RS_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
                 'SELECT geom FROM @@RS_SCHEMA@@.quadbin_polyfill_table_input',
                 17, 'intersects', '@@RS_SCHEMA@@.quadbin_polyfill_table_output')""",

--- a/clouds/redshift/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
+++ b/clouds/redshift/modules/test/quadbin/test_QUADBIN_POLYFILL_TABLE.py
@@ -1,0 +1,47 @@
+from test_utils import run_queries
+
+
+POLYGON = (
+    'POLYGON ((-3.71219873428345 40.413365349070865,'
+    '-3.7144088745117 40.40965661286395,'
+    '-3.70659828186035 40.409525904775634,'
+    '-3.71219873428345 40.413365349070865))'
+)
+
+# Expected quadbin coverage of the test polygon at resolution 17.
+EXPECTED_CELLS = sorted(
+    [
+        5265786693153193983,
+        5265786693163941887,
+        5265786693164204031,
+        5265786693164466175,
+        5265786693164728319,
+        5265786693165514751,
+    ]
+)
+
+
+def test_quadbin_polyfill_table():
+    results = run_queries(
+        [
+            'drop table if exists @@RS_SCHEMA@@.quadbin_polyfill_table_input',
+            'drop table if exists @@RS_SCHEMA@@.quadbin_polyfill_table_output',
+            'create table @@RS_SCHEMA@@.quadbin_polyfill_table_input(geom GEOMETRY)',
+            f"""insert into @@RS_SCHEMA@@.quadbin_polyfill_table_input
+                values (ST_GeomFromText('{POLYGON}'))""",
+            """call @@RS_SCHEMA@@.QUADBIN_POLYFILL_TABLE(
+                'SELECT geom FROM @@RS_SCHEMA@@.quadbin_polyfill_table_input',
+                17, 'intersects', '@@RS_SCHEMA@@.quadbin_polyfill_table_output')""",
+            """select quadbin from @@RS_SCHEMA@@.quadbin_polyfill_table_output
+                order by quadbin""",
+        ]
+    )
+    cells = sorted(int(result[0]) for result in results)
+    assert cells == EXPECTED_CELLS
+
+    run_queries(
+        [
+            'drop table if exists @@RS_SCHEMA@@.quadbin_polyfill_table_input',
+            'drop table if exists @@RS_SCHEMA@@.quadbin_polyfill_table_output',
+        ]
+    )

--- a/clouds/snowflake/modules/benchmark/quadbin/QUADBIN_POLYFILL_TABLE.bench.js
+++ b/clouds/snowflake/modules/benchmark/quadbin/QUADBIN_POLYFILL_TABLE.bench.js
@@ -1,0 +1,6 @@
+const { benchmark } = require('../../../common/benchmark-utils');
+
+benchmark({
+    function: 'QUADBIN_POLYFILL_TABLE',
+    sql: "CALL @@SF_SCHEMA@@.QUADBIN_POLYFILL_TABLE('${input_query}', ${resolution}, '${mode}', '${output_table}')"
+});

--- a/clouds/snowflake/modules/doc/h3/H3_POLYFILL_TABLE.md
+++ b/clouds/snowflake/modules/doc/h3/H3_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## H3_POLYFILL_TABLE (BETA)
+## H3_POLYFILL_TABLE
 
 ```sql:signature
 H3_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/snowflake/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/snowflake/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,4 +1,4 @@
-## QUADBIN_POLYFILL_TABLE (BETA)
+## QUADBIN_POLYFILL_TABLE
 
 ```sql:signature
 QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)

--- a/clouds/snowflake/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
+++ b/clouds/snowflake/modules/doc/quadbin/QUADBIN_POLYFILL_TABLE.md
@@ -1,0 +1,47 @@
+## QUADBIN_POLYFILL_TABLE (BETA)
+
+```sql:signature
+QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table)
+```
+
+**Description**
+
+Creates a table with the quadbin cell indexes contained in the geographies of the input query at a requested resolution. All the attributes except the geography will be included in the output table, clustered by the quadbin column.
+
+Unlike [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill), which returns the cells as an array, this procedure writes the result directly to a table. This avoids the array size limits that can be reached when polyfilling large geographies at high resolutions.
+
+**Input parameters**
+
+* `input_query`: `STRING` input data to polyfill. It must contain a column `geom` with the shape to cover. Additionally, other columns can be included.
+* `resolution`: `INT` level of detail. The value must be between 0 and 26.
+* `mode`: `STRING` `<center|contains|intersects>`. Accepted for forward compatibility. The native coverage produced by [`QUADBIN_POLYFILL`](quadbin#quadbin_polyfill) is used regardless of the value; mode-specific containment will be supported in a future release.
+* `output_table`: `STRING` qualified name of the output table, e.g. `<my-database>.<my-schema>.<my-output-table>`.
+
+**Output**
+
+The results are stored in the table named `<my-output-table>`, which contains the following columns:
+
+* `quadbin`: `BIGINT` the quadbin cell index.
+* The rest of columns included in `input_query` except `geom`.
+
+**Examples**
+
+```sql
+CALL carto.QUADBIN_POLYFILL_TABLE(
+  'SELECT ST_GEOGFROMTEXT(''POLYGON ((-3.71219873428345 40.413365349070865, -3.7144088745117 40.40965661286395, -3.70659828186035 40.409525904775634, -3.71219873428345 40.413365349070865))'') AS geom',
+  17, 'intersects',
+  '<my-database>.<my-schema>.<my-output-table>'
+);
+-- The table `<my-database>.<my-schema>.<my-output-table>` will be created
+-- with column: quadbin
+```
+
+```sql
+CALL carto.QUADBIN_POLYFILL_TABLE(
+  'SELECT geom, name, value FROM <my-database>.<my-schema>.<my-table>',
+  17, 'center',
+  '<my-database>.<my-schema>.<my-output-table>'
+);
+-- The table `<my-database>.<my-schema>.<my-output-table>` will be created
+-- with columns: quadbin, name, value
+```

--- a/clouds/snowflake/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
+++ b/clouds/snowflake/modules/sql/quadbin/QUADBIN_POLYFILL_TABLE.sql
@@ -1,0 +1,30 @@
+--------------------------------
+-- Copyright (C) 2026 CARTO
+--------------------------------
+
+CREATE OR REPLACE PROCEDURE @@SF_SCHEMA@@.QUADBIN_POLYFILL_TABLE
+(
+    input_query STRING,
+    resolution INT,
+    mode STRING,
+    output_table STRING
+)
+RETURNS STRING
+LANGUAGE SQL
+EXECUTE AS CALLER
+AS $$
+BEGIN
+    -- NOTE: the `mode` parameter is accepted for forward compatibility. There
+    -- is no mode-aware QUADBIN_POLYFILL yet, so the native coverage produced by
+    -- QUADBIN_POLYFILL is used regardless of the requested `mode`. Full
+    -- center/intersects/contains support will arrive with QUADBIN_POLYFILL_MODE.
+    EXECUTE IMMEDIATE '
+        CREATE OR REPLACE TABLE ' || output_table || ' CLUSTER BY (QUADBIN) AS
+        WITH __input AS ( ' || input_query || ' )
+        SELECT CAST(cell.value AS BIGINT) AS quadbin, i.* EXCLUDE(geom)
+        FROM __input AS i, TABLE(FLATTEN(@@SF_SCHEMA@@.QUADBIN_POLYFILL(geom, ' || resolution || '))) AS cell;
+    ';
+
+    RETURN 'Quadbin Polyfill result added in table ' || output_table;
+END;
+$$;

--- a/clouds/snowflake/modules/test/quadbin/QUADBIN_POLYFILL_TABLE.test.js
+++ b/clouds/snowflake/modules/test/quadbin/QUADBIN_POLYFILL_TABLE.test.js
@@ -1,0 +1,18 @@
+const { runQuery } = require('../../../common/test-utils');
+
+test('QUADBIN_POLYFILL_TABLE should work', async () => {
+    const outputTable = 'quadbin_polyfill_table_test';
+    await runQuery(`DROP TABLE IF EXISTS ${outputTable}`);
+    await runQuery(`CALL QUADBIN_POLYFILL_TABLE(
+        'SELECT ST_GEOGFROMTEXT(''POLYGON ((-3.71219873428345 40.413365349070865, -3.7144088745117 40.40965661286395, -3.70659828186035 40.409525904775634, -3.71219873428345 40.413365349070865))'') AS geom',
+        17, 'intersects',
+        '${outputTable}'
+    )`);
+    const rows = await runQuery(`SELECT ARRAY_TO_STRING(
+        ARRAY_AGG(quadbin) WITHIN GROUP (ORDER BY quadbin), ','
+    ) AS OUTPUT FROM ${outputTable}`);
+    expect(rows.length).toEqual(1);
+    expect(rows[0].OUTPUT).toEqual(
+        '5265786693153193983,5265786693163941887,5265786693164204031,5265786693164466175,5265786693164728319,5265786693165514751');
+    await runQuery(`DROP TABLE IF EXISTS ${outputTable}`);
+});


### PR DESCRIPTION
## What

Adds `QUADBIN_POLYFILL_TABLE` and `H3_POLYFILL_TABLE` stored procedures that write the polyfill result **directly to an output table** instead of returning an `ARRAY`. This sidesteps the platform array-size hard limits (e.g. the 16 MB array limit in [sc-342849](https://app.shortcut.com/cartoteam/story/342849)) when polyfilling large geographies at high resolutions — the array is only ever an intermediate step toward a table.

Story: [sc-344469](https://app.shortcut.com/cartoteam/story/344469)

## Procedure signature (all clouds)

```sql
CALL carto.QUADBIN_POLYFILL_TABLE(input_query, resolution, mode, output_table);
CALL carto.H3_POLYFILL_TABLE(input_query, resolution, mode, output_table);
```

`input_query` must expose a `geom` column; every other column is carried through to the output table alongside the `quadbin`/`h3` index column (except `geom`).

## Coverage

| Cloud | H3_POLYFILL_TABLE | QUADBIN_POLYFILL_TABLE |
|-------|:---:|:---:|
| BigQuery | already shipped | already shipped |
| Postgres | **added** | **added** |
| Snowflake | already shipped | **added** |
| Oracle | already shipped | **added** |
| Databricks | n/a (no native H3) | **added** |
| Redshift | n/a (no native H3) | **added** |

`QUADBIN_POLYFILL_TABLE` goes from BigQuery-only to all 6 clouds.

## Mode handling

The signature is identical everywhere so it never has to change. Actual mode support tracks the underlying polyfill:

- **Fully mode-aware** (center/intersects/contains): BigQuery, Postgres.
- **Mode accepted, not yet refining**: Snowflake, Oracle, Databricks, Redshift — accept `mode` for forward compatibility but produce the native `QUADBIN_POLYFILL` coverage (a tile-cover, equivalent to `intersects`) regardless of the value.

**Redshift:** `QUADBIN_POLYFILL` resolves through the AT Gateway (Lambda), so each input geometry's polyfill is bounded by the gateway response size; very large single-geometry polyfills may exceed it (documented in the doc page).

## Per-cloud implementation notes

- **Postgres / Redshift:** `plpgsql` procedure; materializes the input to introspect columns (no `SELECT * EXCEPT`), then dynamic CTAS. Redshift unnests the gateway `SUPER` array via PartiQL.
- **Snowflake:** `EXECUTE IMMEDIATE` + `FLATTEN`, mirroring the existing `H3_POLYFILL_TABLE`.
- **Oracle:** CTAS consuming the pipelined `QUADBIN_POLYFILL`, with `DBMS_ASSERT` identifier sanitization and NULL-on-invalid no-op.
- **Databricks:** SQL-scripting procedure (`EXECUTE IMMEDIATE FORMAT_STRING` + `LATERAL VIEW EXPLODE` + `* EXCEPT (geom)`).

## Tests / docs / benchmarks

Each procedure ships with a doc page, a benchmark script (+ local `config.json` entry; committed `config.template.json` untouched), and a test (Snowflake included). Tests share the Madrid-polygon fixture and assert the same canonical cells as BigQuery for the mode exercised. SQL/Python/JS/Markdown all pass lint locally; cloud test suites run against live warehouses.

## Follow-up

`QUADBIN_POLYFILL_MODE` (true center/intersects/contains) for Snowflake, Oracle, Databricks, Redshift — net-new work (no Python/JS reference exists; the mode logic lives only as native SQL in BigQuery/Postgres). To be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)