### PR TITLE
fix(db|quadbin): balance single quotes in __QUADBIN_POLYFILL_GEOJSON so Databricks install parses [sc-558226]

### DIFF
--- a/.claude/rules/databricks.md
+++ b/.claude/rules/databricks.md
@@ -37,6 +37,40 @@ make build-modules             # Build module packages
 - Deploy scripts in `clouds/databricks/common/`: `run_query.py`, `create_schema.py`
 - Schema creation runs automatically during deploy
 
+## Python UDF `$$` bodies: keep single quotes balanced
+
+The documented customer install pastes the whole `modules.sql` into the
+Databricks **SQL editor** and runs it ("Run all"). That splitter tracks `'…'`
+string literals to know where statements end. An **odd number of single quotes**
+inside an `AS $$ … $$` Python body opens a string that never closes, so the
+splitter skips the closing `$$;` and merges the **next** `CREATE` into the
+statement, producing:
+
+```
+[PARSE_SYNTAX_ERROR] Syntax error at or near 'CREATE': extra input 'CREATE'. SQLSTATE: 42601
+```
+
+The usual culprit is an **apostrophe in a Python `#` comment** (`it's`,
+`variable's`, `don't`). The build strips `--` SQL comments but **not** Python
+`#` comments, so they ship verbatim into `modules.sql`. This caused sc-558226
+(and earlier sc-533564).
+
+Rules when writing/editing `$$` Python UDFs for Databricks:
+
+- Every `AS $$ … $$` body must contain an **even** number of `'`. Avoid
+  apostrophes — write "it is" not "it's"; rephrase possessives.
+- Prefer `"…"` double quotes for Python string literals where practical.
+
+Verify before committing (flags any odd-parity body — must print nothing):
+
+```bash
+for f in $(grep -rl 'AS \$\$' clouds/databricks/modules/sql); do
+  awk -v F="$f" '/AS \$\$/{b=1;q=0;s=NR;next}
+    /^\$\$;/{if(b){if(q%2)print "ODD single-quote parity:",F":"s"-"NR; b=0}}
+    b{q+=gsub(/'"'"'/,"",$0)}' "$f"
+done
+```
+
 ## Placeholder conventions
 
 In docs, benchmark `config.template.json`, and any user-facing example: use `<my-catalog>.<my-schema>.<my-table>` for input tables and `<my-catalog>.<my-schema>.<my-output-table>` for procedure-output tables. Keep the namespace depth (<my-catalog>.<my-schema>) consistent across files.

--- a/clouds/databricks/modules/sql/quadbin/QUADBIN_POLYFILL.sql
+++ b/clouds/databricks/modules/sql/quadbin/QUADBIN_POLYFILL.sql
@@ -162,7 +162,7 @@ def polygon_cover(geom, zoom):
             m = (j + 1) % ring_length
             y = ring[j][1]
 
-            #  add intersection if it's not local extremum or duplicate
+            #  add intersection if it is not local extremum or duplicate
             if (
                 (y > ring[k][1] or y > ring[m][1])
                 and (y < ring[k][1] or y < ring[m][1])


### PR DESCRIPTION
## Problem

Installing the Analytics Toolbox for Databricks via the **documented** SQL-editor + SQL Warehouse path (paste `modules.sql` → Run all) fails at parse time:

```
[PARSE_SYNTAX_ERROR] Syntax error at or near 'CREATE': extra input 'CREATE'. SQLSTATE: 42601 (line 279, pos 0)
== SQL ==
CREATE OR REPLACE FUNCTION ....__QUADBIN_POLYFILL_GEOJSON ...
```

Reported by **Zoox** (sc-558226); recurrence of sc-533564.

## Root cause (verified on a real SQL Warehouse)

Not file size — it's **single-quote parity**. The inlined `quadbin-py` body of `__QUADBIN_POLYFILL_GEOJSON` contained a lone apostrophe in a comment (`# … if it's not …`), making the `AS $$ … $$` block contain an **odd** number of `'`. The Databricks SQL-editor "Run all" splitter tracks `'…'` string literals; the unbalanced apostrophe opens a string that never closes, so the splitter **ignores the `$$;` terminator** and merges the following `CREATE` into the statement → the server then rejects the second `CREATE` as `extra input`.

Evidence:
- The 3 `$$` Python bodies in the databricks module: only the GEOJSON one had odd parity (3 quotes) — and it's the only one that fails. The other two (0 and 2 quotes) install fine.
- Reproduced the exact `42601 / line 279` error against a real SQL Warehouse by submitting the GEOJSON `CREATE` + next `CREATE` merged; submitting them split installs cleanly.
- A quote-aware splitter simulation merges 12 `CREATE`s into the GEOJSON chunk **before** this change and isolates it correctly **after**.

## Fix

Rephrase the comment `it's` → `it is`, restoring even quote parity. Comment-only; no behavior change. After the fix all three `$$` bodies are even-parity and the full `modules.sql` deploys 23/23 statements.

## Note / follow-ups
- A sibling offender exists in **premium** statistics (`__SCORING_FIRST_PC.sql`, `variable's`) — fixed in a companion PR on the AT repo.
- Recommend a lint guard that fails on odd single-quote parity inside `$$` bodies to prevent recurrence (this is the second time this class of bug has shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)