### PR TITLE
chore(bq): Pin Node version in BigQuery production deploy jobs

### DIFF
--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
@@ -134,7 +134,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
@@ -134,7 +134,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -84,6 +84,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Check diff
         uses: technote-space/get-diff-action@v6
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:
@@ -129,6 +133,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Check diff
         uses: technote-space/get-diff-action@v6
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
## Summary

The BigQuery production deploy to `carto-os` / `carto-os-eu` (and the internal CD deploy) was failing with:

```
[__ENVELOPE] ERROR: Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close
make[2]: *** [Makefile:79: deploy] Error 1
```

This was originally reported as a service-account permissions/key problem. It is not:

- The deploy SA for these projects (`deploy-cloud-extensions@bqcarto`) holds full IAM (`dataOwner`, `jobUser`, `storage.admin`, `connectionAdmin`) on both `carto-os` and `carto-os-eu`.
- The SA key stored in the `BQCARTO_DEPLOY_CLOUD_EXTENSIONS_SA_BASE64` secret is still present, enabled, and non-expiring; the SA is not disabled.
- The failing run was retried 6 times and failed identically each time, so it is not a transient network blip.

## Root cause

The `deploy` and `deploy-internal` jobs are missing the `actions/setup-node` step, so `make deploy` (which runs `common/run-script.js` → `@google-cloud/bigquery`) executes on the GitHub runner's *system* Node. The `ubuntu-24.04` image has moved its default Node forward, and the pinned `@google-cloud/bigquery@7.9.0` / `gaxios` auth stack throws `Premature close` on the OAuth token fetch under the newer Node.

This is a confirmed environment regression, not a never-worked job:

- The `deploy` job has existed unchanged since 2022 (#314) and never had `setup-node`.
- It last deployed to `carto-os` / `carto-os-eu` **green on 2026-03-27** (run `23640067531`).
- The releases in between (2026-05-28, 2025-12-31, 2025-11-28) skipped the BigQuery deploy (no BQ file changes), so 2026-06-26 was the first BQ deploy since March — and it failed.

The `test` job in this same workflow pins Node to `NODE_VERSION` (20.19) via `setup-node` and runs the exact same `make deploy` against the CI project — and succeeds. Every job in the sibling `analytics-toolbox` (non-core) repo, including its production `deploy` job (`make deploy production=1`), pins Node the same way and deploys successfully. The only structural difference between every working deploy and the failing one is the missing `setup-node` step.

## Changes

Add the `Setup Node` step (pinning to `${{ env.NODE_VERSION }}` = 20.19), matching the `test` job and the non-core repo, to:

- `deploy` — production deploy to `carto-os` / `carto-os-eu`
- `deploy-internal` — internal CD deploy

This re-pins the deploy jobs to a Node version proven to work today (the `test` job and the entire non-core repo run the same token fetch on 20.19 and succeed).

## Notes for reviewers

- `publish` is intentionally left unchanged — it only runs `make create-package` + `gsutil` and performs no OAuth token fetch, and it was passing.
- Final confirmation is the next BigQuery release running the deploy job green.
- Follow-up worth considering separately: the other clouds' deploy jobs (notably `databricks.yml`, which has no `setup-node` at all) likely share this latent gap, and committing a lockfile + bumping `@google-cloud/bigquery` off 7.9.0 would remove the Node-version fragility entirely.

[sc-558923](https://app.shortcut.com/cartoteam/story/558923)