### PR TITLE
chore(bq): pin Node in BigQuery production deploy jobs (stable) [sc-558923]

### DIFF
--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -38,7 +38,7 @@ jobs:
           !(startsWith(github.event.pull_request.head.ref, 'release/'))
         run: echo "BQ_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google

--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -38,7 +38,7 @@ jobs:
           !(startsWith(github.event.pull_request.head.ref, 'release/'))
         run: echo "BQ_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google

--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -38,7 +38,7 @@ jobs:
           !(startsWith(github.event.pull_request.head.ref, 'release/'))
         run: echo "BQ_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -84,6 +84,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Check diff
         uses: technote-space/get-diff-action@v6
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:
@@ -129,6 +133,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Check diff
         uses: technote-space/get-diff-action@v6
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
@@ -85,7 +85,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
@@ -134,7 +134,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
@@ -85,7 +85,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google
@@ -134,7 +134,7 @@ jobs:
       - name: Check diff
         uses: technote-space/get-diff-action@v6
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Auth google


### PR DESCRIPTION
## Summary

Same fix as #625, but targeting **`stable`** — because the production BigQuery deploy to `carto-os` / `carto-os-eu` runs from the `publish-release` flow on `stable`, so the fix has to be on `stable` for the release/publish to go green.

Adds the missing `actions/setup-node` step (pinning Node to `NODE_VERSION` = 20.19) to the `deploy` and `deploy-internal` jobs in `bigquery.yml`.

## Root cause (recap of #625)

The `deploy` / `deploy-internal` jobs had no `setup-node`, so `make deploy` (→ `@google-cloud/bigquery@7.9.0` / `gaxios`) ran on the runner's **system Node**. `ubuntu-24.04` moved its default Node forward, and the pinned auth stack throws on the OAuth token fetch under the newer Node:

```
[__ENVELOPE] ERROR: Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close
make: *** [Makefile:91: deploy] Error 2
```

It is **not** permissions, not a key/SA problem, and not transient (failed identically on 6 retries):

- The `test` job in this same workflow pins Node via `setup-node` and runs the exact same `make deploy` against the CI project — and succeeds.
- Every job in the sibling `analytics-toolbox` repo (incl. its production `deploy`) pins Node and works.
- Last green BQ deploy was 2026-03-27; intervening releases skipped the BQ deploy (no BQ changes), so 2026-06-26 was the first BQ deploy since — and the first time the newer system Node bit.

## Change

`bigquery.yml`: add to both `deploy` and `deploy-internal`, right after `Check diff`:

```yaml
      - name: Setup Node
        uses: actions/setup-node@v1
        with:
          node-version: ${{ env.NODE_VERSION }}
```

Identical to #625 (+8 lines, two steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
