### PR TITLE
fix(sf): pin @azure/core-paging to 1.6.2 for node 20 CI compatibility

### DIFF
--- a/clouds/snowflake/common/package.json
+++ b/clouds/snowflake/common/package.json
@@ -1,7 +1,8 @@
 {
   "license": "BSD-3-Clause",
   "resolutions": {
-    "@azure/storage-blob": "12.32.0"
+    "@azure/storage-blob": "12.32.0",
+    "@azure/core-paging": "1.6.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",

--- a/clouds/snowflake/common/package.json
+++ b/clouds/snowflake/common/package.json
@@ -2,7 +2,17 @@
   "license": "BSD-3-Clause",
   "resolutions": {
     "@azure/storage-blob": "12.32.0",
-    "@azure/core-paging": "1.6.2"
+    "@azure/core-paging": "1.6.2",
+    "@azure/logger": "1.3.0",
+    "@azure/core-xml": "1.5.1",
+    "@azure/core-auth": "1.10.1",
+    "@azure/core-util": "1.13.1",
+    "@azure/core-client": "1.10.2",
+    "@azure/core-tracing": "1.3.1",
+    "@azure/abort-controller": "2.1.2",
+    "@azure/core-http-compat": "2.4.0",
+    "@azure/core-rest-pipeline": "1.24.0",
+    "@typespec/ts-http-runtime": "0.3.6"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
## What

Extends the `resolutions` block in `clouds/snowflake/common/package.json` to pin every `@azure/*` runtime package (plus the `@typespec/ts-http-runtime` transitive) to its last Node-20-compatible version.

## Why

The Azure SDK shipped a **coordinated release** requiring `node >= 22` across its runtime packages, which breaks `yarn install` on the Node 20.19 CI runners for every Snowflake job in this repo and the premium AT repo (first seen: [analytics-toolbox#1115](https://github.com/CartoDB/analytics-toolbox/pull/1115); `main` here was green on 2026-07-10):

```
error @azure/core-paging@1.7.0: The engine "node" is incompatible with this module. Expected version ">=22.0.0". Got "20.19.6"
error @azure/logger@1.4.0: The engine "node" is incompatible with this module. Expected version ">=22.0.0". Got "20.19.6"
```

Pinned (last Node-20-compatible / latest-in-range): `core-paging` 1.6.2, `logger` 1.3.0, `core-xml` 1.5.1, `core-auth` 1.10.1, `core-util` 1.13.1, `core-client` 1.10.2, `core-tracing` 1.3.1, `abort-controller` 2.1.2, `core-http-compat` 2.4.0, `core-rest-pipeline` 1.24.0, `@typespec/ts-http-runtime` 0.3.6. Not pinned: `storage-common` (12.4.1 still supports Node 20) and `core-lro` (in-range 2.7.2 supports Node ≥ 18).

Same approach as the pre-existing `@azure/storage-blob` pin in this file. The structural alternative — bumping CI to Node 22 across all workflows (both repos) — is worth doing deliberately later; this unblocks all PRs now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)