### PR TITLE
chore(ora): source Oracle CD secrets from GCP Secret Manager [sc-562575]

### DIFF
--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -30,7 +30,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
       - name: Extract Oracle credentials (CD)
         id: ora-creds
         env:
@@ -39,8 +39,8 @@ jobs:
           set -eu
           extract() {
             key="$1"; name="$2"
-            value="$(jq -er ".providers.oracle.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
-              echo "Missing '${key}' at providers.oracle.credentials in credentials JSON" >&2
+            value="$(jq -er ".databases.oracle.config.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
+              echo "Missing '${key}' at databases.oracle.config.credentials in credentials JSON" >&2
               exit 1
             }
             echo "::add-mask::${value}"

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -18,14 +18,19 @@ jobs:
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dedicated_oracle'))
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    env:
-      ORA_USER: ${{ secrets.ORA_USER_CD }}
-      ORA_PASSWORD: ${{ secrets.ORA_PASSWORD_CD }}
-      ORA_WALLET_ZIP: ${{ secrets.ORA_WALLET_ZIP_CD }}
-      ORA_WALLET_PASSWORD: ${{ secrets.ORA_WALLET_PASSWORD_CD }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+      - name: Auth google
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+      - name: Retrieve secrets (CD)
+        id: get-gcp-secrets-cd
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          secrets: |-
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
       - name: Set ORA_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
@@ -54,12 +59,24 @@ jobs:
       - name: Run deploy
         id: deploy
         if: github.event.action == 'synchronize' || github.event.action == 'labeled'
+        env:
+          ORA_USER: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.user }}
+          ORA_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.password }}
+          ORA_WALLET_ZIP: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletZip }}
+          ORA_WALLET_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletPassword }}
+          ORA_CONNECTION_STRING: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.connectionString }}
         run: |
           cd clouds/oracle
           make deploy
       - name: Run remove
         id: remove
         if: github.event.action == 'unlabeled' || github.event.action == 'closed'
+        env:
+          ORA_USER: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.user }}
+          ORA_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.password }}
+          ORA_WALLET_ZIP: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletZip }}
+          ORA_WALLET_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletPassword }}
+          ORA_CONNECTION_STRING: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.connectionString }}
         run: |
           cd clouds/oracle
           make remove drop-schema=1

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -30,7 +30,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
       - name: Extract Oracle credentials (CD)
         id: ora-creds
         env:

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -30,7 +30,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
       - name: Extract Oracle credentials (CD)
         id: ora-creds
         env:
@@ -39,8 +39,8 @@ jobs:
           set -eu
           extract() {
             key="$1"; name="$2"
-            value="$(jq -er ".databases.oracle.config.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
-              echo "Missing '${key}' at databases.oracle.config.credentials in credentials JSON" >&2
+            value="$(jq -er ".providers.oracle.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
+              echo "Missing '${key}' at providers.oracle.credentials in credentials JSON" >&2
               exit 1
             }
             echo "::add-mask::${value}"

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -30,7 +30,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
       - name: Set ORA_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -31,6 +31,30 @@ jobs:
         with:
           secrets: |-
             ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
+      - name: Extract Oracle credentials (CD)
+        id: ora-creds
+        env:
+          ORA_DB_CREDENTIALS: ${{ steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS }}
+        run: |
+          set -eu
+          extract() {
+            key="$1"; name="$2"
+            value="$(jq -er ".databases.oracle.config.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
+              echo "Missing '${key}' at databases.oracle.config.credentials in credentials JSON" >&2
+              exit 1
+            }
+            echo "::add-mask::${value}"
+            {
+              echo "${name}<<__OUT__"
+              echo "${value}"
+              echo "__OUT__"
+            } >> "${GITHUB_OUTPUT}"
+          }
+          extract user ORA_USER
+          extract password ORA_PASSWORD
+          extract walletZip ORA_WALLET_ZIP
+          extract walletPassword ORA_WALLET_PASSWORD
+          extract connectionString ORA_CONNECTION_STRING
       - name: Set ORA_PREFIX for releases
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
@@ -60,11 +84,11 @@ jobs:
         id: deploy
         if: github.event.action == 'synchronize' || github.event.action == 'labeled'
         env:
-          ORA_USER: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.user }}
-          ORA_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.password }}
-          ORA_WALLET_ZIP: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletZip }}
-          ORA_WALLET_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletPassword }}
-          ORA_CONNECTION_STRING: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.connectionString }}
+          ORA_USER: ${{ steps.ora-creds.outputs.ORA_USER }}
+          ORA_PASSWORD: ${{ steps.ora-creds.outputs.ORA_PASSWORD }}
+          ORA_WALLET_ZIP: ${{ steps.ora-creds.outputs.ORA_WALLET_ZIP }}
+          ORA_WALLET_PASSWORD: ${{ steps.ora-creds.outputs.ORA_WALLET_PASSWORD }}
+          ORA_CONNECTION_STRING: ${{ steps.ora-creds.outputs.ORA_CONNECTION_STRING }}
         run: |
           cd clouds/oracle
           make deploy
@@ -72,11 +96,11 @@ jobs:
         id: remove
         if: github.event.action == 'unlabeled' || github.event.action == 'closed'
         env:
-          ORA_USER: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.user }}
-          ORA_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.password }}
-          ORA_WALLET_ZIP: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletZip }}
-          ORA_WALLET_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletPassword }}
-          ORA_CONNECTION_STRING: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.connectionString }}
+          ORA_USER: ${{ steps.ora-creds.outputs.ORA_USER }}
+          ORA_PASSWORD: ${{ steps.ora-creds.outputs.ORA_PASSWORD }}
+          ORA_WALLET_ZIP: ${{ steps.ora-creds.outputs.ORA_WALLET_ZIP }}
+          ORA_WALLET_PASSWORD: ${{ steps.ora-creds.outputs.ORA_WALLET_PASSWORD }}
+          ORA_CONNECTION_STRING: ${{ steps.ora-creds.outputs.ORA_CONNECTION_STRING }}
         run: |
           cd clouds/oracle
           make remove drop-schema=1

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -129,6 +129,31 @@ jobs:
         with:
           secrets: |-
             ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
+      - name: Extract Oracle credentials (CD)
+        if: matrix.target == 'cd'
+        id: ora-creds
+        env:
+          ORA_DB_CREDENTIALS: ${{ steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS }}
+        run: |
+          set -eu
+          extract() {
+            key="$1"; name="$2"
+            value="$(jq -er ".databases.oracle.config.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
+              echo "Missing '${key}' at databases.oracle.config.credentials in credentials JSON" >&2
+              exit 1
+            }
+            echo "::add-mask::${value}"
+            {
+              echo "${name}<<__OUT__"
+              echo "${value}"
+              echo "__OUT__"
+            } >> "${GITHUB_OUTPUT}"
+          }
+          extract user ORA_USER
+          extract password ORA_PASSWORD
+          extract walletZip ORA_WALLET_ZIP
+          extract walletPassword ORA_WALLET_PASSWORD
+          extract connectionString ORA_CONNECTION_STRING
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -141,25 +166,13 @@ jobs:
           python-version: ${{ env.PYTHON3_VERSION }}
       - name: Setup virtualenv
         run: pip install virtualenv==${{ env.VIRTUALENV_VERSION }}
-      - name: Run deploy (CI)
-        if: matrix.target == 'ci'
+      - name: Run deploy
         env:
-          ORA_USER: ${{ steps.get-gcp-secrets.outputs.ORA_USER }}
-          ORA_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_PASSWORD }}
-          ORA_WALLET_ZIP: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_ZIP }}
-          ORA_WALLET_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_PASSWORD }}
-          ORA_CONNECTION_STRING: ${{ steps.get-gcp-secrets.outputs.ORA_CONNECTION_STRING }}
-        run: |
-          cd clouds/oracle
-          make deploy production=1
-      - name: Run deploy (CD)
-        if: matrix.target == 'cd'
-        env:
-          ORA_USER: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.user }}
-          ORA_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.password }}
-          ORA_WALLET_ZIP: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletZip }}
-          ORA_WALLET_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletPassword }}
-          ORA_CONNECTION_STRING: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.connectionString }}
+          ORA_USER: ${{ steps.get-gcp-secrets.outputs.ORA_USER || steps.ora-creds.outputs.ORA_USER }}
+          ORA_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_PASSWORD || steps.ora-creds.outputs.ORA_PASSWORD }}
+          ORA_WALLET_ZIP: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_ZIP || steps.ora-creds.outputs.ORA_WALLET_ZIP }}
+          ORA_WALLET_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_PASSWORD || steps.ora-creds.outputs.ORA_WALLET_PASSWORD }}
+          ORA_CONNECTION_STRING: ${{ steps.get-gcp-secrets.outputs.ORA_CONNECTION_STRING || steps.ora-creds.outputs.ORA_CONNECTION_STRING }}
         run: |
           cd clouds/oracle
           make deploy production=1

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -128,7 +128,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -101,29 +101,17 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        include:
-          - target: cd
-            user: ORA_USER_CD
-            password: ORA_PASSWORD_CD
-            wallet_zip: ORA_WALLET_ZIP_CD
-            wallet_password: ORA_WALLET_PASSWORD_CD
-          - target: ci
-    env:
-      ORA_USER: ${{ secrets[matrix.user] }}
-      ORA_PASSWORD: ${{ secrets[matrix.password] }}
-      ORA_WALLET_ZIP: ${{ secrets[matrix.wallet_zip] }}
-      ORA_WALLET_PASSWORD: ${{ secrets[matrix.wallet_password] }}
+        target: [cd, ci]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Check diff
         uses: technote-space/get-diff-action@v6
-      - name: Auth google (CI only)
-        if: matrix.target == 'ci'
+      - name: Auth google
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
-      - name: Retrieve secrets (CI only)
+      - name: Retrieve secrets (CI)
         if: matrix.target == 'ci'
         id: get-gcp-secrets
         uses: google-github-actions/get-secretmanager-secrets@v2
@@ -134,6 +122,13 @@ jobs:
             ORA_WALLET_ZIP:${{ secrets.ORA_WALLET_ZIP_NAME_CI }}
             ORA_WALLET_PASSWORD:${{ secrets.ORA_WALLET_PASSWORD_NAME_CI }}
             ORA_CONNECTION_STRING:${{ secrets.ORA_CONNECTION_STRING_NAME_CI }}
+      - name: Retrieve secrets (CD)
+        if: matrix.target == 'cd'
+        id: get-gcp-secrets-cd
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          secrets: |-
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -146,13 +141,25 @@ jobs:
           python-version: ${{ env.PYTHON3_VERSION }}
       - name: Setup virtualenv
         run: pip install virtualenv==${{ env.VIRTUALENV_VERSION }}
-      - name: Run deploy
+      - name: Run deploy (CI)
+        if: matrix.target == 'ci'
         env:
-          ORA_USER: ${{ steps.get-gcp-secrets.outputs.ORA_USER || secrets[matrix.user] }}
-          ORA_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_PASSWORD || secrets[matrix.password] }}
-          ORA_WALLET_ZIP: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_ZIP || secrets[matrix.wallet_zip] }}
-          ORA_WALLET_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_PASSWORD || secrets[matrix.wallet_password] }}
+          ORA_USER: ${{ steps.get-gcp-secrets.outputs.ORA_USER }}
+          ORA_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_PASSWORD }}
+          ORA_WALLET_ZIP: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_ZIP }}
+          ORA_WALLET_PASSWORD: ${{ steps.get-gcp-secrets.outputs.ORA_WALLET_PASSWORD }}
           ORA_CONNECTION_STRING: ${{ steps.get-gcp-secrets.outputs.ORA_CONNECTION_STRING }}
+        run: |
+          cd clouds/oracle
+          make deploy production=1
+      - name: Run deploy (CD)
+        if: matrix.target == 'cd'
+        env:
+          ORA_USER: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.user }}
+          ORA_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.password }}
+          ORA_WALLET_ZIP: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletZip }}
+          ORA_WALLET_PASSWORD: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.walletPassword }}
+          ORA_CONNECTION_STRING: ${{ fromJSON(steps.get-gcp-secrets-cd.outputs.ORA_DB_CREDENTIALS).databases.oracle.config.credentials.connectionString }}
         run: |
           cd clouds/oracle
           make deploy production=1

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -128,7 +128,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
       - name: Extract Oracle credentials (CD)
         if: matrix.target == 'cd'
         id: ora-creds
@@ -138,8 +138,8 @@ jobs:
           set -eu
           extract() {
             key="$1"; name="$2"
-            value="$(jq -er ".databases.oracle.config.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
-              echo "Missing '${key}' at databases.oracle.config.credentials in credentials JSON" >&2
+            value="$(jq -er ".providers.oracle.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
+              echo "Missing '${key}' at providers.oracle.credentials in credentials JSON" >&2
               exit 1
             }
             echo "::add-mask::${value}"

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -128,7 +128,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
       - name: Extract Oracle credentials (CD)
         if: matrix.target == 'cd'
         id: ora-creds

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -128,7 +128,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2
         with:
           secrets: |-
-            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-golden-dataset-credentials
+            ORA_DB_CREDENTIALS:projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials
       - name: Extract Oracle credentials (CD)
         if: matrix.target == 'cd'
         id: ora-creds
@@ -138,8 +138,8 @@ jobs:
           set -eu
           extract() {
             key="$1"; name="$2"
-            value="$(jq -er ".providers.oracle.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
-              echo "Missing '${key}' at providers.oracle.credentials in credentials JSON" >&2
+            value="$(jq -er ".databases.oracle.config.credentials.${key}" <<< "${ORA_DB_CREDENTIALS}")" || {
+              echo "Missing '${key}' at databases.oracle.config.credentials in credentials JSON" >&2
               exit 1
             }
             echo "::add-mask::${value}"


### PR DESCRIPTION
## What

Migrate the Oracle **CD / dedicated** database credentials from GitHub Actions secrets (`ORA_USER_CD`, `ORA_PASSWORD_CD`, `ORA_WALLET_ZIP_CD`, `ORA_WALLET_PASSWORD_CD`) to GCP Secret Manager.

The five login values (user, password, walletZip, walletPassword, connectionString) come from the bundled JSON secret `projects/carto-terraform-ci-cd/secrets/carto-dev-database-credentials`, parsed by a dedicated **jq extraction step** (cloud-native convention, cf. `dedicated-release.yml`) at path `databases.oracle.config.credentials.*`:

- each value is masked in logs via `::add-mask::`
- a JSON shape mismatch fails the extract step with a clear per-key error
- consuming steps reference plain step outputs; `deploy-internal` keeps a single `Run deploy` step using the existing `||` output-fallback idiom

Note: `carto-golden-dataset-credentials` was tried (its Oracle creds live at `providers.oracle.credentials.*` and were verified with a live connection), but the GH Actions service account lacks access to it in CI, so this PR targets the dev bundle. Switching to golden later is a two-line change per file (secret name + jq path).

## Validation

- Extraction script tested locally against the real dev bundle: all 5 values extracted; wrong-shape JSON fails loudly.
- Live Oracle connection verified with the dev credentials (auth OK, `SELECT 1 FROM dual`, TNS alias resolves in the wallet).
- ⚠️ The GH Actions service account needs `roles/secretmanager.secretAccessor` on `carto-dev-database-credentials` — confirm with infra if the retrieve step still fails with PERMISSION_DENIED.
- Do **not** delete the original `_CD` GitHub secrets until the CD deploy is green on `main`.

Shortcut: [sc-562575]

Companion premium PR: CartoDB/analytics-toolbox#1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)