### PR TITLE
chore(bq|sf|rs|pg|db|ora): reliable dedicated/CI env cleanup and unified env naming [sc-564479]

### DIFF
--- a/.claude/rules/bigquery.md
+++ b/.claude/rules/bigquery.md
@@ -29,6 +29,8 @@ cd clouds/bigquery
 make deploy   # deploy modules
 make test     # run tests (Jest)
 make build    # build JS libraries + SQL modules
+make remove   # drop deployed functions
+make remove drop-schema=1  # drop entire dataset with CASCADE (destructive)
 ```
 
 ## Key Details

--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -21,12 +21,12 @@ Each cloud has its own CI/CD workflows in `.github/workflows/`:
 | BigQuery | `bigquery.yml` | `bigquery-ded.yml` |
 | Snowflake | `snowflake.yml` | `snowflake-ded.yml` |
 | Redshift | `redshift.yml` | `redshift-ded.yml` |
-| Databricks | `databricks.yml` | - |
+| Databricks | `databricks.yml` | `databricks-ded.yml` |
 | Postgres | `postgres.yml` | `postgres-ded.yml` |
 | Oracle | `oracle.yml` | `oracle-ded.yml` |
 
 - **Main workflows**: Triggered on PRs and pushes to main. Run lint, deploy to CI env, test, cleanup.
-- **Dedicated (`-ded`) workflows**: PR-triggered, deploy to isolated environment for testing.
+- **Dedicated (`-ded`) workflows**: PR-triggered, deploy to isolated environment for testing. Envs are named `dedicated_core_<PR>_carto` — the `core_` infix keeps the namespace disjoint from the premium Analytics Toolbox repo, whose dedicated envs are `dedicated_<PR>_carto` in the same CD warehouses.
 - **Publish**: Triggered by `publish-release.yml` on push to `stable`. Creates GitHub Release, publishes packages to GCS, deploys to production.
 
 ## Diff Parameter Handling in Makefiles

--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -25,7 +25,7 @@ Each cloud has its own CI/CD workflows in `.github/workflows/`:
 | Postgres | `postgres.yml` | `postgres-ded.yml` |
 | Oracle | `oracle.yml` | `oracle-ded.yml` |
 
-- **Main workflows**: Triggered on PRs and pushes to main. Run lint, deploy to CI env, test, cleanup.
+- **Main workflows**: Triggered on PRs and pushes to main. Run lint, deploy to CI env, test, cleanup. The cleanup step runs under `if: always()` with `drop-schema=1`, so the `ci_*` schema is dropped with CASCADE even when lint/deploy/test fails; a failed cleanup fails the workflow (no `|| true` masking).
 - **Dedicated (`-ded`) workflows**: PR-triggered, deploy to isolated environment for testing. Envs are named `dedicated_core_<PR>_carto` — the `core_` infix keeps the namespace disjoint from the premium Analytics Toolbox repo, whose dedicated envs are `dedicated_<PR>_carto` in the same CD warehouses.
 - **Publish**: Triggered by `publish-release.yml` on push to `stable`. Creates GitHub Release, publishes packages to GCS, deploys to production.
 

--- a/.claude/rules/databricks.md
+++ b/.claude/rules/databricks.md
@@ -28,6 +28,7 @@ make deploy                    # Deploy SQL UDFs
 make test                      # Run all tests (pytest)
 make test modules=quadbin      # Run tests for specific module
 make build-modules             # Build module packages
+make remove                    # Drop entire schema with CASCADE (destructive)
 ```
 
 ## Key Details

--- a/.claude/rules/postgres.md
+++ b/.claude/rules/postgres.md
@@ -24,6 +24,8 @@ cd clouds/postgres
 make deploy   # deploy modules
 make test     # run tests (pytest)
 make build    # build JS libraries + SQL modules
+make remove   # drop deployed functions
+make remove drop-schema=1  # drop entire schema with CASCADE (destructive)
 ```
 
 ## Key Details

--- a/.claude/rules/redshift.md
+++ b/.claude/rules/redshift.md
@@ -46,6 +46,8 @@ make test modules=h3               # Specific module
 make test functions=H3_POLYFILL    # Specific function
 make deploy                        # Deploy SQL UDFs
 make lint                          # Run linter
+make remove                        # Drop deployed functions
+make remove drop-schema=1          # Drop entire schema with CASCADE (destructive)
 
 # Gateway deployment (from gateway/)
 cd gateway

--- a/.claude/rules/snowflake.md
+++ b/.claude/rules/snowflake.md
@@ -32,6 +32,8 @@ make test                 # run tests (Jest)
 make build                # build JS libraries + SQL modules
 make deploy-native-app    # deploy native app
 make deploy-share         # deploy data share
+make remove               # drop deployed functions
+make remove drop-schema=1 # drop entire schema with CASCADE (destructive)
 ```
 
 ## Key Details

--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Set BQ_PREFIX
-        run: echo "BQ_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+        run: echo "BQ_PREFIX=dedicated_core_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -24,18 +24,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Set BQ_PREFIX for releases
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo "BQ_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set BQ_PREFIX for hotfixes
-        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        run: |
-          echo "BQ_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set BQ_PREFIX for regular deploys
-        if: |
-          !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
-          !(startsWith(github.event.pull_request.head.ref, 'release/'))
+      - name: Set BQ_PREFIX
         run: echo "BQ_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -63,7 +52,7 @@ jobs:
         if: github.event.action == 'unlabeled' || github.event.action == 'closed'
         run: |
           cd clouds/bigquery
-          make remove
+          make remove drop-schema=1
       - name: Comment deploy PR
         if: steps.deploy.outcome == 'success' && github.event.action == 'labeled'
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -56,12 +56,22 @@ jobs:
           python-version: ${{ env.PYTHON3_VERSION }}
       - name: Setup virtualenv
         run: pip install virtualenv==${{ env.VIRTUALENV_VERSION }}
-      - name: Run linter and tests
+      - name: Run lint
         run: |
           cd clouds/bigquery
-          make lint && \
-          make deploy diff="$GIT_DIFF" && \
-          make test diff="$GIT_DIFF" && \
+          make lint
+      - name: Run deploy
+        run: |
+          cd clouds/bigquery
+          make deploy diff="$GIT_DIFF"
+      - name: Run test
+        run: |
+          cd clouds/bigquery
+          make test diff="$GIT_DIFF"
+      - name: Run remove
+        if: always()
+        run: |
+          cd clouds/bigquery
           make remove drop-schema=1
 
   deploy-internal:

--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -62,7 +62,7 @@ jobs:
           make lint && \
           make deploy diff="$GIT_DIFF" && \
           make test diff="$GIT_DIFF" && \
-          make remove
+          make remove drop-schema=1
 
   deploy-internal:
     if: github.ref_name == 'main'

--- a/.github/workflows/databricks-ded.yml
+++ b/.github/workflows/databricks-ded.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Set DB_PREFIX
-        run: echo "DB_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+        run: echo "DB_PREFIX=dedicated_core_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/databricks-ded.yml
+++ b/.github/workflows/databricks-ded.yml
@@ -24,18 +24,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-      - name: Set DB_PREFIX for releases
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo "DB_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set DB_PREFIX for hotfixes
-        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        run: |
-          echo "DB_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set DB_PREFIX for the rest
-        if: |
-          !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
-          !(startsWith(github.event.pull_request.head.ref, 'release/'))
+      - name: Set DB_PREFIX
         run: echo "DB_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -56,7 +56,7 @@ jobs:
           extract walletPassword ORA_WALLET_PASSWORD
           extract connectionString ORA_CONNECTION_STRING
       - name: Set ORA_PREFIX
-        run: echo "ORA_PREFIX=DEDICATED_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+        run: echo "ORA_PREFIX=DEDICATED_CORE_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -55,18 +55,7 @@ jobs:
           extract walletZip ORA_WALLET_ZIP
           extract walletPassword ORA_WALLET_PASSWORD
           extract connectionString ORA_CONNECTION_STRING
-      - name: Set ORA_PREFIX for releases
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo "ORA_PREFIX=DEDICATED_RELEASE_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set ORA_PREFIX for hotfixes
-        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        run: |
-          echo "ORA_PREFIX=DEDICATED_HOTFIX_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set ORA_PREFIX for regular deploys
-        if: |
-          !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
-          !(startsWith(github.event.pull_request.head.ref, 'release/'))
+      - name: Set ORA_PREFIX
         run: echo "ORA_PREFIX=DEDICATED_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/postgres-ded.yml
+++ b/.github/workflows/postgres-ded.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Set PG_PREFIX
-        run: echo "PG_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+        run: echo "PG_PREFIX=dedicated_core_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/postgres-ded.yml
+++ b/.github/workflows/postgres-ded.yml
@@ -26,18 +26,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Set PG_PREFIX for releases
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo "PG_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set PG_PREFIX for hotfixes
-        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        run: |
-          echo "PG_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set PG_PREFIX for regular deploys
-        if: |
-          !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
-          !(startsWith(github.event.pull_request.head.ref, 'release/'))
+      - name: Set PG_PREFIX
         run: echo "PG_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -60,7 +49,7 @@ jobs:
         id: remove
         run: |
           cd clouds/postgres
-          make remove
+          make remove drop-schema=1
       - name: Comment deploy PR
         if: steps.deploy.outcome == 'success' && github.event.action == 'labeled'
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -52,7 +52,7 @@ jobs:
           make lint && \
           make deploy diff="$GIT_DIFF" && \
           make test diff="$GIT_DIFF" && \
-          make remove
+          make remove drop-schema=1
 
   deploy-internal:
     if: github.ref_name == 'main'

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -46,12 +46,22 @@ jobs:
           python-version: ${{ env.PYTHON3_VERSION }}
       - name: Setup virtualenv
         run: pip install virtualenv==${{ env.VIRTUALENV_VERSION }}
-      - name: Run linter and tests
+      - name: Run lint
         run: |
           cd clouds/postgres
-          make lint && \
-          make deploy diff="$GIT_DIFF" && \
-          make test diff="$GIT_DIFF" && \
+          make lint
+      - name: Run deploy
+        run: |
+          cd clouds/postgres
+          make deploy diff="$GIT_DIFF"
+      - name: Run test
+        run: |
+          cd clouds/postgres
+          make test diff="$GIT_DIFF"
+      - name: Run remove
+        if: always()
+        run: |
+          cd clouds/postgres
           make remove drop-schema=1
 
   deploy-internal:

--- a/.github/workflows/redshift-ded.yml
+++ b/.github/workflows/redshift-ded.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Set RS_PREFIX
-        run: echo "RS_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+        run: echo "RS_PREFIX=dedicated_core_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/redshift-ded.yml
+++ b/.github/workflows/redshift-ded.yml
@@ -31,18 +31,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Set RS_PREFIX for releases
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo "RS_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set RS_PREFIX for hotfixes
-        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        run: |
-          echo "RS_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set RS_PREFIX for the rest
-        if: |
-          !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
-          !(startsWith(github.event.pull_request.head.ref, 'release/'))
+      - name: Set RS_PREFIX
         run: echo "RS_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -87,7 +76,7 @@ jobs:
         id: remove
         if: github.event.action == 'unlabeled' || github.event.action == 'closed'
         run: |
-          make remove cloud=redshift drop-schema=1 || echo "Removal (best effort)"
+          make remove cloud=redshift drop-schema=1
       - name: Comment deploy PR
         if: steps.deploy.outcome == 'success' && github.event.action == 'labeled'
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/snowflake-ded.yml
+++ b/.github/workflows/snowflake-ded.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Set SF_PREFIX
-        run: echo "SF_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
+        run: echo "SF_PREFIX=dedicated_core_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/snowflake-ded.yml
+++ b/.github/workflows/snowflake-ded.yml
@@ -25,18 +25,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Set SF_PREFIX for releases
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo "SF_PREFIX=dedicated_release_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set SF_PREFIX for hotfixes
-        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
-        run: |
-          echo "SF_PREFIX=dedicated_hotfix_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
-      - name: Set SF_PREFIX for regular deploys
-        if: |
-          !(startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
-          !(startsWith(github.event.pull_request.head.ref, 'release/'))
+      - name: Set SF_PREFIX
         run: echo "SF_PREFIX=dedicated_${{ github.event.pull_request.number }}_" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -53,7 +42,7 @@ jobs:
         if: github.event.action == 'unlabeled' || github.event.action == 'closed'
         run: |
           cd clouds/snowflake
-          make remove
+          make remove drop-schema=1
       - name: Comment deploy PR
         if: steps.deploy.outcome == 'success' && github.event.action == 'labeled'
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -66,7 +66,7 @@ jobs:
           make lint && \
           make deploy diff="$GIT_DIFF" && \
           make test diff="$GIT_DIFF" && \
-          make remove
+          make remove drop-schema=1
 
   deploy-internal:
     if: github.ref_name == 'main'

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -57,15 +57,31 @@ jobs:
           python-version: ${{ env.PYTHON3_VERSION }}
       - name: Setup virtualenv
         run: pip install virtualenv==${{ env.VIRTUALENV_VERSION }}
-      - name: Run linter and tests
+      - name: Run lint
+        run: |
+          cd clouds/snowflake
+          make lint
+      - name: Run deploy
         env:
           SF_RSA_KEY: ${{ steps.get-gcp-secrets.outputs.SF_RSA_KEY }}
           SF_RSA_KEY_PASSWORD: ${{ steps.get-gcp-secrets.outputs.SF_RSA_KEY_PASSWORD }}
         run: |
           cd clouds/snowflake
-          make lint && \
-          make deploy diff="$GIT_DIFF" && \
-          make test diff="$GIT_DIFF" && \
+          make deploy diff="$GIT_DIFF"
+      - name: Run test
+        env:
+          SF_RSA_KEY: ${{ steps.get-gcp-secrets.outputs.SF_RSA_KEY }}
+          SF_RSA_KEY_PASSWORD: ${{ steps.get-gcp-secrets.outputs.SF_RSA_KEY_PASSWORD }}
+        run: |
+          cd clouds/snowflake
+          make test diff="$GIT_DIFF"
+      - name: Run remove
+        if: always()
+        env:
+          SF_RSA_KEY: ${{ steps.get-gcp-secrets.outputs.SF_RSA_KEY }}
+          SF_RSA_KEY_PASSWORD: ${{ steps.get-gcp-secrets.outputs.SF_RSA_KEY_PASSWORD }}
+        run: |
+          cd clouds/snowflake
           make remove drop-schema=1
 
   deploy-internal:

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,8 @@ endif
 	@echo ""
 	@echo "Removing clouds..."
 	@if [ -d "clouds/$(cloud)" ]; then \
-		cd clouds/$(cloud) && $(MAKE) remove || true; \
+		cd clouds/$(cloud) && $(MAKE) remove \
+			$(if $(drop-schema),drop-schema=$(drop-schema),); \
 	else \
 		echo "  ⓘ No clouds/$(cloud) directory - nothing to remove"; \
 	fi
@@ -191,7 +192,7 @@ endif
 		echo ""; \
 		echo "Removing gateway..."; \
 		cd gateway && $(MAKE) remove cloud=$(cloud) \
-			$(if $(drop-schema),drop-schema=$(drop-schema),) || echo "  ⚠️  Gateway removal (best effort)"; \
+			$(if $(drop-schema),drop-schema=$(drop-schema),); \
 		echo ""; \
 	else \
 		echo ""; \

--- a/clouds/bigquery/modules/Makefile
+++ b/clouds/bigquery/modules/Makefile
@@ -165,9 +165,15 @@ benchmark: check $(NODE_MODULES_DEV)
 
 remove: check
 	echo "Removing modules..."
+ifdef drop-schema
+	echo "Dropping dataset $(BQ_DATASET) with CASCADE..."
+	GOOGLE_APPLICATION_CREDENTIALS=$(GOOGLE_APPLICATION_CREDENTIALS) \
+	$(COMMON_DIR)/run-query.js "DROP SCHEMA IF EXISTS \`$(BQ_DATASET)\` CASCADE;"
+else
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	GOOGLE_APPLICATION_CREDENTIALS=$(GOOGLE_APPLICATION_CREDENTIALS) \
 	$(COMMON_DIR)/run-script.js $(COMMON_DIR)/DROP_FUNCTIONS.sql
+endif
 
 
 clean:

--- a/clouds/postgres/modules/Makefile
+++ b/clouds/postgres/modules/Makefile
@@ -110,8 +110,13 @@ benchmark: check venv3 $(NODE_MODULES_DEV)
 
 remove: venv3
 	echo "Removing modules..."
+ifdef drop-schema
+	echo "Dropping schema $(PG_SCHEMA) with CASCADE..."
+	$(VENV3_BIN)/python $(COMMON_DIR)/run_query.py "DROP SCHEMA IF EXISTS $(PG_SCHEMA) CASCADE;"
+else
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	$(VENV3_BIN)/python $(COMMON_DIR)/run_script.py $(COMMON_DIR)/DROP_FUNCTIONS.sql
+endif
 
 clean:
 	echo "Cleaning modules..."

--- a/clouds/redshift/modules/Makefile
+++ b/clouds/redshift/modules/Makefile
@@ -110,8 +110,13 @@ benchmark: check venv3 $(NODE_MODULES_DEV)
 
 remove: venv3
 	echo "Removing modules..."
+ifdef drop-schema
+	echo "Dropping schema $(RS_SCHEMA) with CASCADE..."
+	$(VENV3_BIN)/python $(COMMON_DIR)/run_query.py "DROP SCHEMA IF EXISTS $(RS_SCHEMA) CASCADE;"
+else
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	$(VENV3_BIN)/python $(COMMON_DIR)/run_script.py $(COMMON_DIR)/DROP_FUNCTIONS.sql
+endif
 
 clean:
 	echo "Cleaning modules..."

--- a/clouds/snowflake/modules/Makefile
+++ b/clouds/snowflake/modules/Makefile
@@ -199,8 +199,13 @@ benchmark: check $(NODE_MODULES_DEV)
 
 remove: $(NODE_MODULES_DEV)
 	echo "Removing modules..."
+ifdef drop-schema
+	echo "Dropping schema $(SF_SCHEMA) with CASCADE..."
+	$(COMMON_DIR)/run-query.js "DROP SCHEMA IF EXISTS $(SF_SCHEMA) CASCADE;"
+else
 	REPLACEMENTS=$(REPLACEMENTS)" "$(REPLACEMENTS_EXTRA) \
 	$(COMMON_DIR)/run-script.js $(COMMON_DIR)/DROP_FUNCTIONS.sql
+endif
 
 
 remove-share: $(NODE_MODULES_DEV)


### PR DESCRIPTION
## Problem

Dedicated (`dedicated_*_carto`) and CI (`ci_*_carto`) environments were not reliably cleaned up:

- **Snowflake / BigQuery / Postgres / Redshift (clouds side)**: `make remove` only dropped functions/procedures one by one via `DROP_FUNCTIONS.sql`. The schema/dataset itself — plus helper procedures and any tables created by tests — was left behind. (Snowflake additionally swallows drop errors inside its JS helper procedures, so CI went green even when nothing was dropped.)
- **CI runs that failed never cleaned up**: Snowflake/BigQuery/Postgres chained `make lint && deploy && test && remove` in a single step, so any failure skipped the remove and leaked the `ci_*` schema.
- **Failures were masked**: `|| true` / best-effort echoes meant orphaned environments produced no signal.
- **Naming**: dedicated envs had three name variants (`dedicated_`, `dedicated_release_`, `dedicated_hotfix_`) with no technical purpose, and core/AT PR numbers could theoretically collide on the same `dedicated_<PR>_carto` name in the shared CD warehouses.

## Changes

- **Makefiles**: add a `drop-schema` option to the Snowflake, BigQuery, Postgres and Redshift modules `remove` targets (`DROP SCHEMA/DATASET IF EXISTS ... CASCADE`, mirroring the existing Oracle pattern; Databricks already dropped its schema). Root Makefile passes `drop-schema` explicitly to the clouds removal and no longer masks removal failures.
- **Ded workflows**: pass `drop-schema=1` on remove; remove failure masking; envs are always named `dedicated_core_<PR>_carto` — the `core_` infix keeps the namespace disjoint from the premium AT repo (`dedicated_<PR>_carto`), so one repo's PR close can never drop the other's live env. Redshift Lambda prefix stays `ded-<PR>-` (CLI enforces a 10-char limit).
- **CI workflows (SF/BQ/PG)**: split the chained step into lint / deploy / test / remove, with remove under `if: always()` and `drop-schema=1` — matching the existing Redshift/Oracle/Databricks pattern, so failed runs clean up too.
- **Docs**: `.claude/rules/` updated — CI/CD workflow table (Databricks ded workflow was missing), naming convention, always-on cleanup, and `make remove [drop-schema=1]` in every cloud's command list.

## Follow-ups (tracked in sc-564479)

- Bump the `core` submodule in CartoDB/analytics-toolbox#1121 after this merges.
- One-off sweep of pre-existing stale `dedicated_*` / `ci_*` schemas.

Shortcut: [sc-564479]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
