### PR TITLE
fix(bq): install node modules before dedicated env removal [sc-565491]

### DIFF
--- a/clouds/bigquery/modules/Makefile
+++ b/clouds/bigquery/modules/Makefile
@@ -163,7 +163,7 @@ benchmark: check $(NODE_MODULES_DEV)
 		echo "  No benchmarks matched (modules=$(modules) functions=$(functions))"; \
 	fi
 
-remove: check
+remove: check $(NODE_MODULES_DEV)
 	echo "Removing modules..."
 ifdef drop-schema
 	echo "Dropping dataset $(BQ_DATASET) with CASCADE..."


### PR DESCRIPTION
## Problem

The BigQuery modules `remove` target is `remove: check` — missing the `$(NODE_MODULES_DEV)` prerequisite that Snowflake's has. In the ded workflows the remove runs on a fresh runner (unlike main CI, where it runs after deploy in the same job), so `run-query.js` fails with `MODULE_NOT_FOUND` (`@google-cloud/bigquery` not installed) and the dedicated env cleanup can never succeed. Latent since the `run-script.js` days; made visible by the failure unmasking in #633.

Observed in #633's cleanup run: https://github.com/CartoDB/analytics-toolbox-core/actions/runs/30898219405 — the orphaned `dedicated_core_633_carto` dataset needs a manual drop (tracked in the ticket).

## Fix

Add `$(NODE_MODULES_DEV)` to the remove target so the deps are installed before the drop runs.

Shortcut: [sc-565491]

🤖 Generated with [Claude Code](https://claude.com/claude-code)