### PR TITLE
fix(sf): unblock Snowflake CI — pin @azure/storage-common and tolerate H3_POLYFILL release drift [sc-565492][sc-565533]

### DIFF
--- a/clouds/snowflake/common/package.json
+++ b/clouds/snowflake/common/package.json
@@ -2,6 +2,7 @@
   "license": "BSD-3-Clause",
   "resolutions": {
     "@azure/storage-blob": "12.32.0",
+    "@azure/storage-common": "12.4.1",
     "@azure/core-paging": "1.6.2",
     "@azure/logger": "1.3.0",
     "@azure/core-xml": "1.5.1",

--- a/clouds/snowflake/modules/test/h3/H3_POLYFILL.test.js
+++ b/clouds/snowflake/modules/test/h3/H3_POLYFILL.test.js
@@ -39,10 +39,11 @@ describe('H3_POLYFILL should support POLYGON geographies', () => {
         ['spain', 6, 'center', 13344],
         ['spain', 6, 'intersects', 13701],
         ['africa', 3, undefined, 2323],
-        ['africa', 3, 'contains', 2178],
+        // A float-borderline edge cell makes the contains count vary across Snowflake releases
+        ['africa', 3, 'contains', [2177, 2178]],
         ['africa', 3, 'center', 2323],
         ['africa', 3, 'intersects', 2470]
-    ])('Called with geography POLYGON:%s, a resolution of %i in %s mode, should return %i H3 cell identifiers', async (polygonName, resolution, mode, expectedCellCount) => {
+    ])('Called with geography POLYGON:%s, a resolution of %i in %s mode, should return %s H3 cell identifiers', async (polygonName, resolution, mode, expectedCellCount) => {
         const polygonWkt = polygonsWkt[polygonName]; // Assuming polygonsWkt is an object with WKT strings
 
         let query = mode === undefined ?
@@ -50,7 +51,11 @@ describe('H3_POLYFILL should support POLYGON geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${polygonWkt}'), ${resolution}, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 
 });
@@ -99,7 +104,11 @@ describe('Support GEOMETRYCOLLECTION containing 1 or more POLYGON Geographies', 
     ])('H3_POLYFILL with mode %s should return expected cell count', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${geometryCollection}'), 6, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -113,7 +122,11 @@ describe('NOT Support a GEOMETRYCOLLECTION containing 0 POLYGON Geographies. Ret
     ])('H3_POLYFILL with mode %s should return expected empty result', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${geometryCollection}'), 6, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -138,7 +151,11 @@ describe('Resolution support between 0 and 15 inclusive for H3_POLYFILL', () => 
         }
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -156,7 +173,11 @@ describe('H3_POLYFILL should not support POINT Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${pointWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -174,7 +195,11 @@ describe('H3_POLYFILL should not support MULTIPOINT Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${multiPointWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -192,7 +217,11 @@ describe('H3_POLYFILL should not support LINESTRING Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${lineStringWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -210,7 +239,11 @@ describe('H3_POLYFILL should not support MULTILINESTRING Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${multiLineStringWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -234,7 +267,11 @@ describe('H3_POLYFILL for Geographies crossing the Prime-Meridian multiple times
     ])('with mode %s, should return expected cell count', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${polygonWkt}'), ${resolution}, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -249,7 +286,11 @@ describe('H3_POLYFILL for POLYGON Geographies over 180 degrees wide', () => {
     ])('with mode %s, should return expected cell count', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${polygonWkt}'), ${resolution}, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 


### PR DESCRIPTION
## Problem

Two independent issues currently break Snowflake CI, and they block each other's PRs (any Snowflake-touching PR needs both to go green), so they ship together here — one commit per issue, tracked by separate tickets.

### 1. `@azure/storage-common@12.5.0` breaks every fresh yarn install (sc-565492)

The transitive dep (via `snowflake-sdk` → `@azure/storage-blob`) declares `engines.node >= 22`; CI runs Node 20.19. `yarn.lock` is not tracked, so every run re-resolves and fails. Same class of breakage as #630. Also breaks the premium AT repo (picks up the fix via its next core submodule bump).

**Fix**: pin `"@azure/storage-common": "12.4.1"` in the existing `resolutions` block. Verified with a clean install using the exact CI command (`yarn -s --update-checksums`).

### 2. `H3_POLYFILL(africa, 3, 'contains')` returns 2177 vs expected 2178 (sc-565533)

Deterministic on the CI account, while a dev account on Snowflake `10.26.102` returns 2178 with byte-identical code (verified by fresh-deploying `main` there). The candidate set is stable (center mode still passes at 2323); the drift is in what `ST_ASGEOJSON(ST_BUFFER(...))` feeds the JS `booleanContains` filter — a float-borderline edge cell flips between Snowflake releases.

**Fix**: the africa/contains fixture accepts `[2177, 2178]` (all other fixtures stay exact), keeping the suite green on both sides of the release rollout.

Replaces #638 (closed; its commit is cherry-picked here unchanged).

Shortcut: [sc-565492] [sc-565533]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
