### PR TITLE
chore(bq|sf|rs|pg|db|ora): unify dedicated env PR comments [sc-565493]

### DIFF
--- a/.github/workflows/bigquery-ded.yml
+++ b/.github/workflows/bigquery-ded.yml
@@ -58,12 +58,12 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated ${{ env.BQ_PREFIX }}carto environment deployed in Bigquery project ${{ env.BQ_PROJECT }}
+            ✅ Dedicated BigQuery environment deployed: dataset `${{ env.BQ_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment remove PR
         if: steps.remove.outcome == 'success' && (github.event.action == 'unlabeled' || github.event.action == 'closed')
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated environment removed
+            🧹 Dedicated BigQuery environment removed: dataset `${{ env.BQ_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/databricks-ded.yml
+++ b/.github/workflows/databricks-ded.yml
@@ -71,12 +71,12 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated ${{ env.DB_PREFIX }}carto environment deployed in Databricks catalog ${{ env.DB_CATALOG }}
+            ✅ Dedicated Databricks environment deployed: schema `${{ env.DB_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment remove PR
         if: steps.remove.outcome == 'success' && (github.event.action == 'unlabeled' || github.event.action == 'closed')
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated environment removed
+            🧹 Dedicated Databricks environment removed: schema `${{ env.DB_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -98,12 +98,12 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated ${{ env.ORA_PREFIX }}CARTO schema deployed in Oracle Autonomous Database
+            ✅ Dedicated Oracle environment deployed: schema `${{ env.ORA_PREFIX }}CARTO`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment remove PR
         if: steps.remove.outcome == 'success' && (github.event.action == 'unlabeled' || github.event.action == 'closed')
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated environment removed
+            🧹 Dedicated Oracle environment removed: schema `${{ env.ORA_PREFIX }}CARTO`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/postgres-ded.yml
+++ b/.github/workflows/postgres-ded.yml
@@ -55,12 +55,12 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated ${{ env.PG_PREFIX }}carto environment deployed in Postgres host ${{ env.PG_HOST }} and ${{ env.PG_DATABASE }} database
+            ✅ Dedicated Postgres environment deployed: schema `${{ env.PG_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment remove PR
         if: steps.remove.outcome == 'success' && (github.event.action == 'unlabeled' || github.event.action == 'closed')
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated environment removed
+            🧹 Dedicated Postgres environment removed: schema `${{ env.PG_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/redshift-ded.yml
+++ b/.github/workflows/redshift-ded.yml
@@ -82,14 +82,14 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated ${{ env.RS_PREFIX }}carto environment deployed in Redshift host ${{ env.RS_HOST }} and ${{ env.RS_DATABASE }} database
-            - Gateway functions (Lambda): ${{ env.RS_LAMBDA_PREFIX }}*
-            - Clouds functions (SQL UDFs): deployed
+            ✅ Dedicated Redshift environment deployed: schema `${{ env.RS_PREFIX }}carto`
+            - Lambda functions: `${{ env.RS_LAMBDA_PREFIX }}*`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment remove PR
         if: steps.remove.outcome == 'success' && (github.event.action == 'unlabeled' || github.event.action == 'closed')
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated environment removed
+            🧹 Dedicated Redshift environment removed: schema `${{ env.RS_PREFIX }}carto`
+            - Lambda functions: `${{ env.RS_LAMBDA_PREFIX }}*`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snowflake-ded.yml
+++ b/.github/workflows/snowflake-ded.yml
@@ -48,12 +48,12 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated ${{ env.SF_PREFIX }}carto environment deployed in Snowflake database ${{ env.SF_ACCOUNT }}.${{ env.SF_PROJECT }}
+            ✅ Dedicated Snowflake environment deployed: schema `${{ env.SF_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment remove PR
         if: steps.remove.outcome == 'success' && (github.event.action == 'unlabeled' || github.event.action == 'closed')
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Dedicated environment removed
+            🧹 Dedicated Snowflake environment removed: schema `${{ env.SF_PREFIX }}carto`
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The dedicated env PR comments were inconsistent across clouds, the removal one was fully generic ("Dedicated environment removed" — impossible to tell which cloud/schema when a PR has several dedicated labels), and the deploy ones echoed secret-derived values (account, host, project, catalog) into public PR comments.

## Changes

Unified format for all 6 clouds, naming the cloud and the schema/dataset on both sides, with no secrets:

- `✅ Dedicated <Cloud> environment deployed: schema \`<prefix>carto\``
- `🧹 Dedicated <Cloud> environment removed: schema \`<prefix>carto\``

BigQuery says `dataset`, Oracle uses `<PREFIX>CARTO`, and Redshift adds a `- Lambda functions: \`<lambda-prefix>*\`` line to both.

A twin PR applies the same format to the premium AT repo.

Shortcut: [sc-565493]

🤖 Generated with [Claude Code](https://claude.com/claude-code)