### PR TITLE
fix(sf|h3): tolerate Snowflake release drift in H3_POLYFILL contains-mode africa fixture [sc-565533]

### DIFF
--- a/clouds/snowflake/modules/test/h3/H3_POLYFILL.test.js
+++ b/clouds/snowflake/modules/test/h3/H3_POLYFILL.test.js
@@ -39,10 +39,11 @@ describe('H3_POLYFILL should support POLYGON geographies', () => {
         ['spain', 6, 'center', 13344],
         ['spain', 6, 'intersects', 13701],
         ['africa', 3, undefined, 2323],
-        ['africa', 3, 'contains', 2178],
+        // A float-borderline edge cell makes the contains count vary across Snowflake releases
+        ['africa', 3, 'contains', [2177, 2178]],
         ['africa', 3, 'center', 2323],
         ['africa', 3, 'intersects', 2470]
-    ])('Called with geography POLYGON:%s, a resolution of %i in %s mode, should return %i H3 cell identifiers', async (polygonName, resolution, mode, expectedCellCount) => {
+    ])('Called with geography POLYGON:%s, a resolution of %i in %s mode, should return %s H3 cell identifiers', async (polygonName, resolution, mode, expectedCellCount) => {
         const polygonWkt = polygonsWkt[polygonName]; // Assuming polygonsWkt is an object with WKT strings
 
         let query = mode === undefined ?
@@ -50,7 +51,11 @@ describe('H3_POLYFILL should support POLYGON geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${polygonWkt}'), ${resolution}, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 
 });
@@ -99,7 +104,11 @@ describe('Support GEOMETRYCOLLECTION containing 1 or more POLYGON Geographies', 
     ])('H3_POLYFILL with mode %s should return expected cell count', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${geometryCollection}'), 6, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -113,7 +122,11 @@ describe('NOT Support a GEOMETRYCOLLECTION containing 0 POLYGON Geographies. Ret
     ])('H3_POLYFILL with mode %s should return expected empty result', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${geometryCollection}'), 6, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -138,7 +151,11 @@ describe('Resolution support between 0 and 15 inclusive for H3_POLYFILL', () => 
         }
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -156,7 +173,11 @@ describe('H3_POLYFILL should not support POINT Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${pointWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -174,7 +195,11 @@ describe('H3_POLYFILL should not support MULTIPOINT Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${multiPointWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -192,7 +217,11 @@ describe('H3_POLYFILL should not support LINESTRING Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${lineStringWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -210,7 +239,11 @@ describe('H3_POLYFILL should not support MULTILINESTRING Geographies', () => {
             `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${multiLineStringWkt}'), 6, '${mode}')) as cell_count`;
 
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -234,7 +267,11 @@ describe('H3_POLYFILL for Geographies crossing the Prime-Meridian multiple times
     ])('with mode %s, should return expected cell count', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${polygonWkt}'), ${resolution}, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 
@@ -249,7 +286,11 @@ describe('H3_POLYFILL for POLYGON Geographies over 180 degrees wide', () => {
     ])('with mode %s, should return expected cell count', async (mode, expectedCellCount) => {
         const query = `SELECT ARRAY_SIZE(H3_POLYFILL(TO_GEOGRAPHY('${polygonWkt}'), ${resolution}, '${mode}')) as cell_count`;
         const rows = await runQuery(query);
-        expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        if (Array.isArray(expectedCellCount)) {
+            expect(expectedCellCount).toContain(rows[0].CELL_COUNT);
+        } else {
+            expect(rows[0].CELL_COUNT).toEqual(expectedCellCount);
+        }
     });
 });
 


### PR DESCRIPTION
## Problem

`H3_POLYFILL(africa, 3, 'contains')` fails deterministically in CI: expected 2178 cells, received 2177 (confirmed twice on https://github.com/CartoDB/analytics-toolbox-core/actions/runs/30916924966). This currently blocks every Snowflake-touching PR, including #636.

## Root cause — Snowflake release drift, not a code change

The SQL (`H3_POLYFILL.sql`, unchanged since Apr 2024) builds the candidate set with native `H3_POLYGON_TO_CELLS_STRINGS` (center mode — still passes at 2323, so the candidate set is stable) and filters with the bundled turf `booleanContains` (JS lib unchanged since Oct 2025) on `ST_ASGEOJSON(ST_BUFFER(...))` output.

Verification: fresh-deploying current `main` to a dev account on Snowflake `10.26.102` returns **2178**, while the CI account returns **2177** — byte-identical code, two Snowflake releases, one float-borderline edge cell flipping between contained/not-contained (most likely a serialization/precision change feeding the JS filter).

## Fix

Accept `[2177, 2178]` for this one fixture (the assertion stays exact for every other case), so the suite is green on both sides of the release rollout. If Snowflake later stabilizes on one value, the fixture can be re-pinned.

Shortcut: [sc-565533]

🤖 Generated with [Claude Code](https://claude.com/claude-code)