### PR TITLE
fix(rs): validate function name in gateway deploy CLI

### DIFF
--- a/gateway/logic/clouds/redshift/cli.py
+++ b/gateway/logic/clouds/redshift/cli.py
@@ -341,6 +341,9 @@ def deploy_external_function(
         package_version: Package version for @@PACKAGE_VERSION@@ template variable
         max_batch_rows: Maximum rows per Lambda batch invocation
     """
+    if not validate_sql_identifier(function_name, "function name"):
+        logger.error(f"Invalid function name '{function_name}'. Aborting for security.")
+        sys.exit(1)
     # Render SQL template
     renderer = TemplateRenderer()
     sql = renderer.render_external_function(


### PR DESCRIPTION
## Summary
Fix high severity security issue in `gateway/logic/clouds/redshift/cli.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `gateway/logic/clouds/redshift/cli.py:1000` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-89 |

**Description**: While schema names are validated, the function_name parameter used in SQL queries is NOT validated before being used in f-string SQL construction. This creates a SQL injection vulnerability where function names containing SQL metacharacters can break out of string context.

## Evidence

**Exploitation scenario**: Control function name through deployment configuration with value like `my_func'; DELETE FROM _gw_udfs_info; --`.

**Scanner confirmation**: multi_agent_ai rule `V-003` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `gateway/logic/clouds/redshift/cli.py`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `gateway/logic/clouds/redshift/cli.py:1701`, `gateway/logic/clouds/redshift/cli.py:1706`, `gateway/logic/clouds/redshift/cli.py:1709`, `gateway/logic/clouds/redshift/cli.py:1715`, `gateway/logic/clouds/redshift/cli.py:1727` (and 1 more)

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
