### PR TITLE
fix(rs): validate function name in gateway deploy CLI

### DIFF
--- a/gateway/logic/clouds/redshift/cli.py
+++ b/gateway/logic/clouds/redshift/cli.py
@@ -341,6 +341,9 @@ def deploy_external_function(
         package_version: Package version for @@PACKAGE_VERSION@@ template variable
         max_batch_rows: Maximum rows per Lambda batch invocation
     """
+    if not validate_sql_identifier(function_name, "function name"):
+        logger.error(f"Invalid function name '{function_name}'. Aborting for security.")
+        sys.exit(1)
     # Render SQL template
     renderer = TemplateRenderer()
     sql = renderer.render_external_function(


### PR DESCRIPTION
## Summary
Cherry-pick of #639 onto an internal branch so CI can run with secrets (fork PRs don't receive them, so the Redshift integration job cannot pass there).

Validates `function_name` with the existing `validate_sql_identifier()` helper in `deploy_external_function()` (`gateway/logic/clouds/redshift/cli.py`), before rendering and executing the external function SQL — same validation already applied to schema names via `resolve_redshift_schema()`.

## Notes
- Original author: @anupamme (authorship preserved in the commit)
- Defense-in-depth hardening: `function_name` comes from the repo's own function catalog, so this is not an exploitable injection path, but validating it is consistent and harmless
- All existing catalog function names match the identifier pattern, so no deployment behavior changes
- Supersedes and closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)