### PR TITLE
chore(ci): 🔒 migrate GitHub Actions auth to WIF

### DIFF
--- a/.github/workflows/databricks-ded.yml
+++ b/.github/workflows/databricks-ded.yml
@@ -16,6 +16,10 @@ jobs:
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'dedicated_databricks')) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dedicated_databricks'))
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     timeout-minutes: 20
     env:
       DB_HOST_NAME: ${{ secrets.DB_HOST_NAME_CD }}
@@ -35,7 +39,8 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Get Databricks secrets
         id: secrets
         uses: google-github-actions/get-secretmanager-secrets@v2

--- a/.github/workflows/databricks.yml
+++ b/.github/workflows/databricks.yml
@@ -23,6 +23,9 @@ jobs:
 
   test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 20
     env:
       DB_PREFIX: ci_${{ github.sha }}_${{ github.run_id }}_${{ github.run_attempt }}_
@@ -43,7 +46,8 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Get Databricks secrets
         id: secrets
         uses: google-github-actions/get-secretmanager-secrets@v2
@@ -76,6 +80,9 @@ jobs:
     if: github.ref_name == 'main'
     needs: test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 10
     env:
       DB_HOST_NAME: ${{ secrets.DB_HOST_NAME_CD }}
@@ -95,7 +102,8 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Get Databricks secrets
         id: secrets
         uses: google-github-actions/get-secretmanager-secrets@v2

--- a/.github/workflows/oracle-ded.yml
+++ b/.github/workflows/oracle-ded.yml
@@ -17,6 +17,10 @@ jobs:
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'dedicated_oracle')) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dedicated_oracle'))
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     timeout-minutes: 20
     steps:
       - name: Checkout repo
@@ -24,7 +28,8 @@ jobs:
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Retrieve secrets (CD)
         id: get-gcp-secrets-cd
         uses: google-github-actions/get-secretmanager-secrets@v2

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -24,6 +24,9 @@ jobs:
 
   test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 55
     env:
       ORA_PREFIX: CI_${{ github.run_id }}_${{ github.run_attempt }}_
@@ -35,7 +38,8 @@ jobs:
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Retrieve secrets
         id: get-gcp-secrets
         uses: google-github-actions/get-secretmanager-secrets@v2
@@ -98,6 +102,9 @@ jobs:
     if: github.ref_name == 'main'
     needs: test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 20
     strategy:
       matrix:
@@ -110,7 +117,8 @@ jobs:
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Retrieve secrets (CI)
         if: matrix.target == 'ci'
         id: get-gcp-secrets

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -24,6 +24,9 @@ jobs:
 
   test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 35
     env:
       SF_PREFIX: ci_${{ github.sha }}_${{ github.run_id }}_${{ github.run_attempt }}_
@@ -39,7 +42,8 @@ jobs:
       - name: Auth google
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Retrieve secrets
         id: get-gcp-secrets
         uses: google-github-actions/get-secretmanager-secrets@v2
@@ -88,6 +92,9 @@ jobs:
     if: github.ref_name == 'main'
     needs: test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 20
     strategy:
       matrix:
@@ -117,7 +124,8 @@ jobs:
         if: matrix.use_rsa_key
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-analytics-toolbox
+          service_account: carto-at-gh-actions@cartodb-on-gcp-terraform-ci-cd.iam.gserviceaccount.com
       - name: Retrieve RSA secrets (CI only)
         if: matrix.use_rsa_key
         id: get-gcp-secrets


### PR DESCRIPTION
## What
Switch the `carto-at-gh-actions` auth steps to keyless **Workload Identity Federation** across `databricks.yml`, `databricks-ded.yml`, `oracle.yml`, `oracle-ded.yml`, `snowflake.yml`.

## Why
Follow-up to CartoDB/carto-infrastructure#680, which provisions the WIF provider `github-analytics-toolbox` (allows `CartoDB/analytics-toolbox` + `-core`) and binds `carto-at-gh-actions`. Removes the long-lived exportable key.

## Changes
- Replace `credentials_json` with `workload_identity_provider` + `service_account`.
- Add `id-token: write` to each affected job; `*-ded.yml` jobs also keep `pull-requests: write` (they post PR comments via `GITHUB_TOKEN`).
- Only the `carto-at-gh-actions` steps change; other SAs (`GCLOUD_PRODUCTION_RELEASE_SA`, `BQCARTO*`) are untouched.

## Notes
- The migrated key was stored in secret `CARTO_AT_GH_ACTIONS_SERVICE_ACCOUNT_KEY` (not the IaC-provisioned name); WIF removes the need for either.

## Ordering
⚠️ Merge **after** carto-infrastructure#680 is applied. Static key deleted in a later follow-up once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)