### PR TITLE
chore(sf): remove the broken h3_fromlonglat JS library entry [sc-569993]

### DIFF
--- a/clouds/snowflake/libraries/javascript/libs/h3_fromlonglat.js
+++ b/clouds/snowflake/libraries/javascript/libs/h3_fromlonglat.js
@@ -1,5 +1,0 @@
-import { geoToH3 } from '../src/h3/h3_fromlonglat/h3core_custom';
-
-export default {
-    geoToH3
-};


### PR DESCRIPTION
## Summary

`clouds/snowflake/libraries/javascript/libs/h3_fromlonglat.js` is dead **and broken**. It imports a path that is not in the tree:

```js
import { geoToH3 } from '../src/h3/h3_fromlonglat/h3core_custom';
```

`src/h3/h3_fromlonglat/` does not exist. Building the library fails outright:

```
[!] Error: Could not resolve '../src/h3/h3_fromlonglat/h3core_custom'
    from core/clouds/snowflake/libraries/javascript/libs/h3_fromlonglat.js
```

Snowflake's `H3_FROMLONGLAT` is now pure SQL over Snowflake's native H3 support:

```sql
IFF(LONGITUDE IS NOT NULL AND LATITUDE IS NOT NULL AND RESOLUTION >= 0 AND RESOLUTION <= 15,
    H3_LATLNG_TO_CELL_STRING(LATITUDE, LONGITUDE, RESOLUTION),
    NULL)
```

The migration to native H3 removed the `src` implementation but left this entry file behind.

## Why CI has not caught it

`@@SF_LIBRARY_H3_FROMLONGLAT@@` is referenced by no SQL file, and `list_libraries.js` derives the build list from SQL placeholders rather than from the `libs/` directory — including in `--all` / `UNIT_TEST` mode. So nothing ever attempts to build it and the breakage stays latent. It would surface the moment anyone referenced the placeholder.

## Impact

None on shipped code. The library was never embedded in `modules.sql`, `list_libraries.js` output is unchanged, and no version bump is needed.

## Context

Found during a dead-code sweep across all six JavaScript library directories in both repos, checking every entry file against the correct placeholder form per cloud (BigQuery uses `@@BQ_LIBRARY_*_BUCKET@@` since it loads from GCS rather than inlining). Only two orphans exist in total — this one, and `polygon_intersection.js` in AT, handled in [CartoDB/analytics-toolbox#1186](https://github.com/CartoDB/analytics-toolbox/pull/1186).

One nearby finding deliberately **not** acted on here: `@turf/jsts` in this package looks unused by name but is load-bearing — it is the provider for `jsts`, `turf-jsts`, `d3-geo`, `@turf/center`, `@turf/helpers` and `@turf/meta`, which this tree imports without declaring. Removing it would break the build. Worth hardening separately by declaring those directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)