### PR TITLE
chore(sf): connect lazily in the Snowflake test harness [sc-570150]

### DIFF
--- a/clouds/snowflake/common/test-utils.js
+++ b/clouds/snowflake/common/test-utils.js
@@ -30,20 +30,38 @@ if (process.env.SF_PASSWORD) {
     });
 }
 
-const connection = snowflake.createConnection(connectionOptions);
+// Connect on first query rather than on import. Jest imports a test file to
+// discover its tests even when they are all skipped, so connecting at module
+// scope left an HTTP request in flight after the suite finished and the
+// environment was torn down. Concurrent callers share one in-flight connect,
+// which keeps the previous one-connection-per-worker behaviour.
+let connection = null;
+let connecting = null;
 
-connection.connect((err) => {
-    if (err) {
-        console.error(`Unable to connect: ${err.message}`);
-    } else {
-        // Optional: store the connection ID.
-        //const connection_ID = conn.getId();
+function getConnection () {
+    if (connection) {
+        return Promise.resolve(connection);
     }
-});
+    if (!connecting) {
+        const conn = snowflake.createConnection(connectionOptions);
+        connecting = new Promise((resolve, reject) => {
+            conn.connect((err) => {
+                if (err) {
+                    connecting = null;
+                    return reject(new Error(`Unable to connect: ${err.message}`));
+                }
+                connection = conn;
+                return resolve(conn);
+            });
+        });
+    }
+    return connecting;
+}
 
-function execAsync (query) {
+async function execAsync (query) {
+    const conn = await getConnection();
     return new Promise((resolve, reject) => {
-        connection.execute({
+        conn.execute({
             sqlText: query,
             complete: (err, stmt, rows) => {
                 if (err) {

--- a/clouds/snowflake/common/test-utils.js
+++ b/clouds/snowflake/common/test-utils.js
@@ -30,29 +30,29 @@ if (process.env.SF_PASSWORD) {
     });
 }
 
-// Connect on first query rather than on import. Jest imports a test file to
+// Connect on first query rather than on import: jest imports a test file to
 // discover its tests even when they are all skipped, so connecting at module
 // scope left an HTTP request in flight after the suite finished and the
-// environment was torn down. Concurrent callers share one in-flight connect,
-// which keeps the previous one-connection-per-worker behaviour.
-let connection = null;
+// environment was torn down.
+//
+// The promise itself is the cache, so concurrent callers share one connect and
+// later callers reuse it. It is cleared on failure so a subsequent call retries
+// rather than latching the error forever.
 let connecting = null;
 
 function getConnection () {
-    if (connection) {
-        return Promise.resolve(connection);
-    }
     if (!connecting) {
         const conn = snowflake.createConnection(connectionOptions);
         connecting = new Promise((resolve, reject) => {
             conn.connect((err) => {
                 if (err) {
-                    connecting = null;
                     return reject(new Error(`Unable to connect: ${err.message}`));
                 }
-                connection = conn;
                 return resolve(conn);
             });
+        }).catch((err) => {
+            connecting = null;
+            throw err;
         });
     }
     return connecting;


### PR DESCRIPTION
## Problem

`clouds/snowflake/common/test-utils.js` opened a Snowflake connection at **module scope**:

```js
const connection = snowflake.createConnection(connectionOptions);

connection.connect((err) => {
    if (err) {
        console.error(`Unable to connect: ${err.message}`);
    }
});
```

Jest imports a test file to discover its tests **even when every test in it is skipped**. So importing fired an async HTTP request — and a suite whose tests are all skipped finishes in milliseconds, jest tears the environment down, and the connect callback lands afterwards:

```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.
From clouds/snowflake/modules/test/data/DATAOBS_ENRICH_GRID.test.js
  at NodeHttpClient.sendRequest (snowflake-sdk/lib/http/base.js:40:21)
```

Jest reports **no test failures** — `10 skipped, 8 passed` — and still exits non-zero, failing the job. A suite whose harness connects on import cannot be skipped.

Surfaced while skipping the deprecated DATAOBS suites in [CartoDB/analytics-toolbox#1167](https://github.com/CartoDB/analytics-toolbox/pull/1167). Snowflake only: BigQuery's `new BigQuery()` builds a client without connecting, and the Redshift pytest marker has no equivalent race.

## Fix

Create and connect on first query. `connection` had exactly one consumer — `connection.execute()` inside `execAsync` — so this is one new function and one changed function.

Concurrent callers share a single in-flight connect promise, which preserves today's one-connection-per-worker behaviour rather than racing several connects. A failed connect clears the promise so a later call can retry instead of latching a permanent failure.

## Secondary benefit

Previously a failed connect only `console.error`d and was swallowed, so every subsequent query failed with a confusing downstream error. Now the first query rejects with the real cause.

## Scope and risk

One file. **Not packaged** — test infrastructure, so no version bump.

156 consumers (76 in `analytics-toolbox`, 80 here), but every one reaches it through `runQuery`/`execAsync`, so any Snowflake CI run exercises the change completely — it works everywhere or fails loudly on the first run.

Two intentional behaviour changes, both minor:
- Connection errors surface at the first query rather than at import.
- The first test in each worker pays connect latency instead of it overlapping module load. Negligible against 20–30s warehouse tests.

## Verification

Beyond this repo's own Snowflake CI, [analytics-toolbox#1167](https://github.com/CartoDB/analytics-toolbox/pull/1167) has its submodule pointed at this branch's commit so the end-to-end case is proven: fully-skipped DATAOBS suites should report as skipped with no post-teardown errors and the job should exit zero. That pointer is for verification only and will be re-pointed at the merged commit on `main` before that PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)