### PR TITLE
chore(sf): ship JavaScript source maps in the native app package [sc-571986]

### DIFF
--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -6,7 +6,6 @@ DIST_DIR ?= $(ROOT_DIR)/dist
 BUILD_DIR ?= $(ROOT_DIR)/build
 ESLINTRC_DIR ?= $(ROOT_DIR)/../..
 COMMON_DIR = $(ROOT_DIR)/common
-LIBS_BUILD_DIR ?= libraries/javascript/build
 PACKAGE_VERSION ?= $(shell cat $(ROOT_DIR)/version)
 PACKAGE_NAME ?= carto-analytics-toolbox-core-snowflake-$(PACKAGE_VERSION)
 
@@ -93,7 +92,7 @@ build-native-app-setup-script:
 # Point each bundle's sourceMappingURL at the package sub-directory, before they are inlined
 prefix-library-sourcemap-urls:
 	echo "Prefixing library sourceMappingURL comments with $(APP_SOURCE_MAPS_DIR)/..."
-	set -e; for f in $(LIBS_BUILD_DIR)/*.js; do \
+	set -e; for f in libraries/javascript/build/*.js; do \
 		sed -i.bak 's|//# sourceMappingURL=|//# sourceMappingURL=$(APP_SOURCE_MAPS_DIR)/|' $$f; \
 		rm -f $$f.bak; \
 	done

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -6,6 +6,7 @@ DIST_DIR ?= $(ROOT_DIR)/dist
 BUILD_DIR ?= $(ROOT_DIR)/build
 ESLINTRC_DIR ?= $(ROOT_DIR)/../..
 COMMON_DIR = $(ROOT_DIR)/common
+LIBS_BUILD_DIR ?= libraries/javascript/build
 PACKAGE_VERSION ?= $(shell cat $(ROOT_DIR)/version)
 PACKAGE_NAME ?= carto-analytics-toolbox-core-snowflake-$(PACKAGE_VERSION)
 
@@ -92,7 +93,7 @@ build-native-app-setup-script:
 # Point each bundle's sourceMappingURL at the package sub-directory, before they are inlined
 prefix-library-sourcemap-urls:
 	echo "Prefixing library sourceMappingURL comments with $(APP_SOURCE_MAPS_DIR)/..."
-	for f in libraries/javascript/build/*.js; do \
+	set -e; for f in $(LIBS_BUILD_DIR)/*.js; do \
 		sed -i.bak 's|//# sourceMappingURL=|//# sourceMappingURL=$(APP_SOURCE_MAPS_DIR)/|' $$f; \
 		rm -f $$f.bak; \
 	done

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -79,7 +79,7 @@ build-modules:
 
 build-native-app-setup-script:
 	rm -rf $(BUILD_DIR)
-	$(MAKE) build-libraries
+	$(MAKE) build-libraries sourcemap=1
 	$(MAKE) prefix-library-sourcemap-urls
 	mkdir -p $(BUILD_DIR)
 	$(MAKE) -C modules build SF_SCHEMA=@@SF_SCHEMA@@

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -84,10 +84,10 @@ build-native-app-setup-script:
 	mkdir -p $(BUILD_DIR)
 	$(MAKE) -C modules build SF_SCHEMA=@@SF_SCHEMA@@
 	cp modules/build/modules.sql $(BUILD_DIR)
-	$(MAKE) -C modules build-native-app-setup-script
-	cp modules/build/setup_script.sql $(BUILD_DIR)
 	$(MAKE) -C modules build-source-review
 	cp modules/build/SOURCE_REVIEW.md $(BUILD_DIR)
+	$(MAKE) -C modules build-native-app-setup-script
+	cp modules/build/setup_script.sql $(BUILD_DIR)
 
 # The app package keeps the source maps in a sub-directory, so the
 # sourceMappingURL comment rollup wrote next to each bundle needs the same

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -89,7 +89,7 @@ build-native-app-setup-script:
 	$(MAKE) -C modules build-source-review
 	cp modules/build/SOURCE_REVIEW.md $(BUILD_DIR)
 
-# Point each bundle's sourceMappingURL at the package sub-directory, before they are inlined
+# Must run before the bundles are inlined into modules.sql
 prefix-library-sourcemap-urls:
 	echo "Prefixing library sourceMappingURL comments with $(APP_SOURCE_MAPS_DIR)/..."
 	set -e; for f in libraries/javascript/build/*.js; do \

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -93,7 +93,7 @@ build-native-app-setup-script:
 prefix-library-sourcemap-urls:
 	echo "Prefixing library sourceMappingURL comments with $(APP_SOURCE_MAPS_DIR)/..."
 	set -e; for f in libraries/javascript/build/*.js; do \
-		sed -i.bak 's|//# sourceMappingURL=|//# sourceMappingURL=$(APP_SOURCE_MAPS_DIR)/|' $$f; \
+		sed -i.bak 's|//# sourceMappingURL=\($(APP_SOURCE_MAPS_DIR)/\)*|//# sourceMappingURL=$(APP_SOURCE_MAPS_DIR)/|' $$f; \
 		rm -f $$f.bak; \
 	done
 

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -13,7 +13,7 @@ include $(COMMON_DIR)/Makefile
 
 .SILENT:
 
-.PHONY: help lint lint-fix build deploy test benchmark remove clean create-package deploy-native-app-package deploy-native-app
+.PHONY: help lint lint-fix build deploy test benchmark remove clean create-package prefix-library-sourcemap-urls deploy-native-app-package deploy-native-app
 
 help:
 	echo "Available targets: lint build deploy test remove clean create-package deploy-native-app-package deploy-native-app"
@@ -80,11 +80,24 @@ build-modules:
 build-native-app-setup-script:
 	rm -rf $(BUILD_DIR)
 	$(MAKE) build-libraries
+	$(MAKE) prefix-library-sourcemap-urls
 	mkdir -p $(BUILD_DIR)
 	$(MAKE) -C modules build SF_SCHEMA=@@SF_SCHEMA@@
 	cp modules/build/modules.sql $(BUILD_DIR)
 	$(MAKE) -C modules build-native-app-setup-script
 	cp modules/build/setup_script.sql $(BUILD_DIR)
+	$(MAKE) -C modules build-source-review
+	cp modules/build/SOURCE_REVIEW.md $(BUILD_DIR)
+
+# The app package keeps the source maps in a sub-directory, so the
+# sourceMappingURL comment rollup wrote next to each bundle needs the same
+# prefix before the bundles are inlined into modules.sql.
+prefix-library-sourcemap-urls:
+	echo "Prefixing library sourceMappingURL comments with $(APP_SOURCE_MAPS_DIR)/..."
+	for f in libraries/javascript/build/*.js; do \
+		sed -i.bak 's|//# sourceMappingURL=|//# sourceMappingURL=$(APP_SOURCE_MAPS_DIR)/|' $$f; \
+		rm -f $$f.bak; \
+	done
 
 deploy:
 	$(MAKE) build-libraries

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -85,10 +85,10 @@ build-native-app-setup-script:
 	mkdir -p $(BUILD_DIR)
 	$(MAKE) -C modules build SF_SCHEMA=@@SF_SCHEMA@@
 	cp modules/build/modules.sql $(BUILD_DIR)
-	$(MAKE) -C modules build-source-review
-	cp modules/build/SOURCE_REVIEW.md $(BUILD_DIR)
 	$(MAKE) -C modules build-native-app-setup-script
 	cp modules/build/setup_script.sql $(BUILD_DIR)
+	$(MAKE) -C modules build-source-review
+	cp modules/build/SOURCE_REVIEW.md $(BUILD_DIR)
 
 # Point each bundle's sourceMappingURL at the package sub-directory, before they are inlined
 prefix-library-sourcemap-urls:

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -89,7 +89,6 @@ build-native-app-setup-script:
 	$(MAKE) -C modules build-source-review
 	cp modules/build/SOURCE_REVIEW.md $(BUILD_DIR)
 
-# Must run before the bundles are inlined into modules.sql
 prefix-library-sourcemap-urls:
 	echo "Prefixing library sourceMappingURL comments with $(APP_SOURCE_MAPS_DIR)/..."
 	set -e; for f in libraries/javascript/build/*.js; do \

--- a/clouds/snowflake/Makefile
+++ b/clouds/snowflake/Makefile
@@ -89,9 +89,7 @@ build-native-app-setup-script:
 	$(MAKE) -C modules build-native-app-setup-script
 	cp modules/build/setup_script.sql $(BUILD_DIR)
 
-# The app package keeps the source maps in a sub-directory, so the
-# sourceMappingURL comment rollup wrote next to each bundle needs the same
-# prefix before the bundles are inlined into modules.sql.
+# Point each bundle's sourceMappingURL at the package sub-directory, before they are inlined
 prefix-library-sourcemap-urls:
 	echo "Prefixing library sourceMappingURL comments with $(APP_SOURCE_MAPS_DIR)/..."
 	for f in libraries/javascript/build/*.js; do \

--- a/clouds/snowflake/common/Makefile
+++ b/clouds/snowflake/common/Makefile
@@ -2,8 +2,7 @@
 
 PYTHON3_VERSION = 3
 
-# Sub-directory of the native app package holding the JavaScript source maps and
-# the source review index (see build_source_review.js).
+# Source maps directory in the app package: the sed prefix, the copy, the PUT and the index must agree
 APP_SOURCE_MAPS_DIR ?= source_review
 
 VENV3_DIR ?= $(COMMON_DIR)/../venv3

--- a/clouds/snowflake/common/Makefile
+++ b/clouds/snowflake/common/Makefile
@@ -2,7 +2,7 @@
 
 PYTHON3_VERSION = 3
 
-# Source maps directory in the app package: the sed prefix, the copy, the PUT and the index must agree
+# The sed prefix, the copy, the PUT and the index must all agree on this
 APP_SOURCE_MAPS_DIR ?= sourcemaps
 
 VENV3_DIR ?= $(COMMON_DIR)/../venv3

--- a/clouds/snowflake/common/Makefile
+++ b/clouds/snowflake/common/Makefile
@@ -3,7 +3,7 @@
 PYTHON3_VERSION = 3
 
 # Source maps directory in the app package: the sed prefix, the copy, the PUT and the index must agree
-APP_SOURCE_MAPS_DIR ?= source_review
+APP_SOURCE_MAPS_DIR ?= sourcemaps
 
 VENV3_DIR ?= $(COMMON_DIR)/../venv3
 VENV3_BIN = $(VENV3_DIR)/bin

--- a/clouds/snowflake/common/Makefile
+++ b/clouds/snowflake/common/Makefile
@@ -1,6 +1,11 @@
 # Makefile common for Snowflake
 
 PYTHON3_VERSION = 3
+
+# Sub-directory of the native app package holding the JavaScript source maps and
+# the source review index (see build_source_review.js).
+APP_SOURCE_MAPS_DIR ?= source_review
+
 VENV3_DIR ?= $(COMMON_DIR)/../venv3
 VENV3_BIN = $(VENV3_DIR)/bin
 NODE_MODULES_DEV = $(COMMON_DIR)/node_modules

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// Build the source review index for the native app package
-// and check every inlined library ships a usable source map
+// Build the source review index and check every inlined library ships a usable source map
 
 // ./build_source_review.js modules --output=build --libs_build_dir=../libraries/javascript/build --source_maps_dir=sourcemaps
 
@@ -31,8 +30,7 @@ for (let inputDir of inputDirs) {
             files.forEach(file => {
                 if (file.endsWith('.sql')) {
                     const name = path.parse(file).name;
-                    // Strip SQL comments as build_modules.js and list_libraries.js do, so a
-                    // commented-out placeholder is not recorded as an inlined library
+                    // Strip comments as build_modules.js does: a commented-out placeholder is not inlined
                     const content = fs.readFileSync(path.join(moduledir, file)).toString().replace(/--.*\n/g, '');
                     const libraries = [... new Set(content.match(/@@SF_LIBRARY_[A-Z0-9_]+@@/g) || [])]
                         .map(l => l.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase());
@@ -45,7 +43,6 @@ for (let inputDir of inputDirs) {
     });
 }
 
-// Invert into library -> functions
 const libraries = {};
 functions.forEach(f => {
     f.libraries.forEach(library => {
@@ -75,13 +72,10 @@ libraryNames.forEach(library => {
     try {
         map = JSON.parse(fs.readFileSync(mapPath).toString());
     } catch (e) {
-        // Report it rather than dying with a raw parse error, so the build failure names the file
         errors.push(`source map "${library}.js.map" is not valid JSON: ${e.message}`);
         return;
     }
-    // Every original must be recoverable from the map alone, which is what the index promises
-    // the reviewer. A non-empty sourcesContent is not enough: a map with no sources at all, or
-    // with null entries, recovers nothing while still satisfying a presence check.
+    // The index promises every original is recoverable from the map alone, so presence is not enough
     const sources = map.sources || [];
     const contents = map.sourcesContent || [];
     const missing = sources.filter((_, i) => typeof contents[i] !== 'string' || contents[i] === '');
@@ -103,7 +97,6 @@ if (errors.length) {
     process.exit(1);
 }
 
-// The document, derived entirely from this build and aimed at whoever reviews the package
 const functionRows = functions
     .sort((a, b) => a.name.localeCompare(b.name))
     .map(f => `| \`${f.name}\` | ${f.libraries.sort().map(l => `\`${sourceMapsDir}/${l}.js.map\``).join(', ')} |`)

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -13,11 +13,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const crypto = require('crypto');
 const { execSync } = require('child_process');
 const argv = require('minimist')(process.argv.slice(2));
-
-const sha256 = contents => crypto.createHash('sha256').update(contents).digest('hex');
 
 const inputDirs = argv._[0] && argv._[0].split(',');
 const outputDir = argv.output || 'build';
@@ -85,11 +82,7 @@ const entries = Object.keys(libraries).sort().map(library => {
     }
     return {
         library,
-        functions: [... new Set(libraries[library])].sort(),
-        bundleSize: bundle.length,
-        mapSize: fs.statSync(mapPath).size,
-        mapSha256: sha256(fs.readFileSync(mapPath)),
-        sources: (map.sources || []).length
+        functions: [... new Set(libraries[library])].sort()
     };
 });
 
@@ -98,67 +91,42 @@ if (errors.length) {
     process.exit(1);
 }
 
-// Build provenance, so the reviewer can reproduce the bundles rather than trust them
-function describeBuild () {
-    let commit = 'unknown';
+// The document. Everything in it is derived from this build: no content is
+// maintained by hand, and it is aimed at whoever reviews the package, so it
+// carries only what is needed to get from minified code to its source.
+function currentCommit () {
     try {
-        commit = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+        return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
     } catch (e) {
-        // Not a git checkout (e.g. building from a package): leave it unknown
+        return null;  // not a git checkout, e.g. building from a package
     }
-    const dependencies = require(path.resolve(__dirname, 'package.json')).devDependencies || {};
-    const versions = ['rollup', 'rollup-plugin-terser']
-        .filter(d => dependencies[d])
-        .map(d => `${d} ${dependencies[d]}`)
-        .join(', ');
-    return { commit, versions };
 }
-
-const { commit, versions } = describeBuild();
-const totalEmbedded = entries.reduce((total, e) => total + e.bundleSize * e.functions.length, 0);
 
 const lines = [];
 lines.push('# Source review');
 lines.push('');
-lines.push('The JavaScript in `modules.sql` is minified. This package includes a source map for');
-lines.push('every library it inlines, so the un-minified code can be recovered from the map alone');
-lines.push('(`sourcesContent` is included).');
+lines.push('The JavaScript inlined in `modules.sql` is minified. Every library it inlines ships');
+lines.push('with its source map in `' + sourceMapsDir + '/`, and each map includes `sourcesContent`, so the');
+lines.push('original un-minified source can be recovered from the map on its own, with no other');
+lines.push('file needed.');
 lines.push('');
-lines.push('Snowflake JavaScript UDFs have no import mechanism: a function body must be entirely');
+lines.push('Snowflake JavaScript UDFs cannot import code: a function body has to be entirely');
 lines.push('self-contained inside its `CREATE FUNCTION` statement. Each library is therefore');
-lines.push('bundled and inlined into every function that uses it, which is why one source map can');
-lines.push('cover several functions. Each inlined bundle ends with a');
-lines.push('`//# sourceMappingURL=` comment naming its map, so every occurrence is linked');
-lines.push('individually from inside the function body.');
+lines.push('bundled and inlined into every function that uses it, which is why one map can cover');
+lines.push('several functions. Every inlined copy ends with a `//# sourceMappingURL=` comment');
+lines.push('naming its map, so each occurrence in `modules.sql` points at its own source.');
 lines.push('');
-lines.push('## Build');
+lines.push('## Reading a source map');
 lines.push('');
-lines.push(`- commit: \`${commit}\``);
-lines.push(`- node: \`${process.version}\``);
-if (versions) {
-    lines.push(`- bundler: \`${versions}\``);
-}
-lines.push('- command: `make deploy-native-app-package production=1`');
-lines.push('- The build is deterministic: rebuilding from this commit reproduces `modules.sql`');
-lines.push('  and the source maps byte-for-byte, so every SHA-256 here can be verified');
-lines.push('  independently.');
+lines.push('A `.map` file is JSON. Two fields carry the original code:');
 lines.push('');
-lines.push('Inlined bundle sizes are the sizes as built. A bundle can differ by a few bytes once');
-lines.push('inlined, because the build substitutes its own `@@...@@` placeholders (the package');
-lines.push('version, for instance) across `modules.sql` after the libraries are inlined.');
+lines.push('- `sources` — the path of each original file that went into the bundle');
+lines.push('- `sourcesContent` — the full text of each of those files, at the same index');
 lines.push('');
-lines.push(`## Libraries (${entries.length})`);
+lines.push('So `sourcesContent[i]` is the complete, un-minified source of `sources[i]`. Browser');
+lines.push('developer tools also load these maps directly and will display the original files.');
 lines.push('');
-entries.forEach(e => {
-    lines.push(`### ${e.library}`);
-    lines.push('');
-    lines.push(`- source map: \`${sourceMapsDir}/${e.library}.js.map\` (${e.mapSize.toLocaleString('en-US')} bytes, ${e.sources} original sources)`);
-    lines.push(`- source map sha256: \`${e.mapSha256}\``);
-    lines.push(`- inlined bundle: ${e.bundleSize.toLocaleString('en-US')} bytes as built`);
-    lines.push(`- inlined into ${e.functions.length} function(s): ${e.functions.map(f => `\`${f}\``).join(', ')}`);
-    lines.push('');
-});
-lines.push('## Functions');
+lines.push('## Which source map covers which function');
 lines.push('');
 lines.push('| Function | Source map |');
 lines.push('| --- | --- |');
@@ -167,15 +135,17 @@ functions.sort((a, b) => a.name.localeCompare(b.name)).forEach(f => {
     lines.push(`| \`${f.name}\` | ${maps} |`);
 });
 lines.push('');
-lines.push('## Totals');
+lines.push('## Libraries');
 lines.push('');
-lines.push(`- ${entries.length} libraries inlined into ${functions.length} functions`);
-lines.push(`- ${totalEmbedded.toLocaleString('en-US')} bytes of minified JavaScript embedded in \`modules.sql\``);
-lines.push(`- ${entries.reduce((total, e) => total + e.mapSize, 0).toLocaleString('en-US')} bytes of source maps`);
-const modulesSqlPath = path.join(outputDir, 'modules.sql');
-if (fs.existsSync(modulesSqlPath)) {
-    const modulesSql = fs.readFileSync(modulesSqlPath);
-    lines.push(`- \`modules.sql\`: ${modulesSql.length.toLocaleString('en-US')} bytes, sha256 \`${sha256(modulesSql)}\``);
+lines.push('| Library | Source map | Functions inlining it |');
+lines.push('| --- | --- | --- |');
+entries.forEach(e => {
+    lines.push(`| ${e.library} | \`${sourceMapsDir}/${e.library}.js.map\` | ${e.functions.length} |`);
+});
+lines.push('');
+const commit = currentCommit();
+if (commit) {
+    lines.push(`Built from commit \`${commit}\`.`);
 }
 
 fs.writeFileSync(path.join(outputDir, 'SOURCE_REVIEW.md'), lines.join('\n'));

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -17,6 +17,8 @@ const crypto = require('crypto');
 const { execSync } = require('child_process');
 const argv = require('minimist')(process.argv.slice(2));
 
+const sha256 = contents => crypto.createHash('sha256').update(contents).digest('hex');
+
 const inputDirs = argv._[0] && argv._[0].split(',');
 const outputDir = argv.output || 'build';
 const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
@@ -85,8 +87,8 @@ const entries = Object.keys(libraries).sort().map(library => {
         library,
         functions: [... new Set(libraries[library])].sort(),
         bundleSize: bundle.length,
-        bundleSha256: crypto.createHash('sha256').update(bundle).digest('hex'),
         mapSize: fs.statSync(mapPath).size,
+        mapSha256: sha256(fs.readFileSync(mapPath)),
         sources: (map.sources || []).length
     };
 });
@@ -137,8 +139,13 @@ if (versions) {
     lines.push(`- bundler: \`${versions}\``);
 }
 lines.push('- command: `make deploy-native-app-package production=1`');
-lines.push('- The build is deterministic: rebuilding from this commit reproduces the bundles');
-lines.push('  byte-for-byte, so the SHA-256 values below can be verified independently.');
+lines.push('- The build is deterministic: rebuilding from this commit reproduces `modules.sql`');
+lines.push('  and the source maps byte-for-byte, so every SHA-256 here can be verified');
+lines.push('  independently.');
+lines.push('');
+lines.push('Inlined bundle sizes are the sizes as built. A bundle can differ by a few bytes once');
+lines.push('inlined, because the build substitutes its own `@@...@@` placeholders (the package');
+lines.push('version, for instance) across `modules.sql` after the libraries are inlined.');
 lines.push('');
 lines.push(`## Libraries (${entries.length})`);
 lines.push('');
@@ -146,7 +153,8 @@ entries.forEach(e => {
     lines.push(`### ${e.library}`);
     lines.push('');
     lines.push(`- source map: \`${sourceMapsDir}/${e.library}.js.map\` (${e.mapSize.toLocaleString('en-US')} bytes, ${e.sources} original sources)`);
-    lines.push(`- inlined bundle: ${e.bundleSize.toLocaleString('en-US')} bytes, sha256 \`${e.bundleSha256}\``);
+    lines.push(`- source map sha256: \`${e.mapSha256}\``);
+    lines.push(`- inlined bundle: ${e.bundleSize.toLocaleString('en-US')} bytes as built`);
     lines.push(`- inlined into ${e.functions.length} function(s): ${e.functions.map(f => `\`${f}\``).join(', ')}`);
     lines.push('');
 });
@@ -164,6 +172,11 @@ lines.push('');
 lines.push(`- ${entries.length} libraries inlined into ${functions.length} functions`);
 lines.push(`- ${totalEmbedded.toLocaleString('en-US')} bytes of minified JavaScript embedded in \`modules.sql\``);
 lines.push(`- ${entries.reduce((total, e) => total + e.mapSize, 0).toLocaleString('en-US')} bytes of source maps`);
+const modulesSqlPath = path.join(outputDir, 'modules.sql');
+if (fs.existsSync(modulesSqlPath)) {
+    const modulesSql = fs.readFileSync(modulesSqlPath);
+    lines.push(`- \`modules.sql\`: ${modulesSql.length.toLocaleString('en-US')} bytes, sha256 \`${sha256(modulesSql)}\``);
+}
 
 fs.writeFileSync(path.join(outputDir, 'SOURCE_REVIEW.md'), lines.join('\n'));
 console.log(`Write ${outputDir}/SOURCE_REVIEW.md (${entries.length} libraries, ${functions.length} functions)`);

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -80,38 +80,40 @@ if (errors.length) {
 }
 
 // The document, derived entirely from this build and aimed at whoever reviews the package
-const lines = [];
-lines.push('# Source review');
-lines.push('');
-lines.push('The JavaScript inlined in `modules.sql` is minified. Every library it inlines ships');
-lines.push('with its source map in `' + sourceMapsDir + '/`, and each map includes `sourcesContent`, so the');
-lines.push('original un-minified source can be recovered from the map on its own, with no other');
-lines.push('file needed.');
-lines.push('');
-lines.push('Snowflake JavaScript UDFs cannot import code: a function body has to be entirely');
-lines.push('self-contained inside its `CREATE FUNCTION` statement. Each library is therefore');
-lines.push('bundled and inlined into every function that uses it, which is why one map can cover');
-lines.push('several functions. Every inlined copy ends with a `//# sourceMappingURL=` comment');
-lines.push('naming its map, so each occurrence in `modules.sql` points at its own source.');
-lines.push('');
-lines.push('## Reading a source map');
-lines.push('');
-lines.push('A `.map` file is JSON. Two fields carry the original code:');
-lines.push('');
-lines.push('- `sources` — the path of each original file that went into the bundle');
-lines.push('- `sourcesContent` — the full text of each of those files, at the same index');
-lines.push('');
-lines.push('So `sourcesContent[i]` is the complete, un-minified source of `sources[i]`. Browser');
-lines.push('developer tools also load these maps directly and will display the original files.');
-lines.push('');
-lines.push('## Which source map covers which function');
-lines.push('');
-lines.push('| Function | Source map |');
-lines.push('| --- | --- |');
-functions.sort((a, b) => a.name.localeCompare(b.name)).forEach(f => {
-    const maps = f.libraries.sort().map(l => `\`${sourceMapsDir}/${l}.js.map\``).join(', ');
-    lines.push(`| \`${f.name}\` | ${maps} |`);
-});
-lines.push('');
-fs.writeFileSync(path.join(outputDir, 'SOURCE_REVIEW.md'), lines.join('\n'));
+const functionRows = functions
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(f => `| \`${f.name}\` | ${f.libraries.sort().map(l => `\`${sourceMapsDir}/${l}.js.map\``).join(', ')} |`)
+    .join('\n');
+
+const document = `# Source review
+
+The JavaScript inlined in \`modules.sql\` is minified. Every library it inlines ships
+with its source map in \`${sourceMapsDir}/\`, and each map includes \`sourcesContent\`, so
+the original un-minified source can be recovered from the map on its own, with no
+other file needed.
+
+Snowflake JavaScript UDFs cannot import code: a function body has to be entirely
+self-contained inside its \`CREATE FUNCTION\` statement. Each library is therefore
+bundled and inlined into every function that uses it, which is why one map can cover
+several functions. Every inlined copy ends with a \`//# sourceMappingURL=\` comment
+naming its map, so each occurrence in \`modules.sql\` points at its own source.
+
+## Reading a source map
+
+A \`.map\` file is JSON. Two fields carry the original code:
+
+- \`sources\` — the path of each original file that went into the bundle
+- \`sourcesContent\` — the full text of each of those files, at the same index
+
+So \`sourcesContent[i]\` is the complete, un-minified source of \`sources[i]\`. Browser
+developer tools also load these maps directly and will display the original files.
+
+## Which source map covers which function
+
+| Function | Source map |
+| --- | --- |
+${functionRows}
+`;
+
+fs.writeFileSync(path.join(outputDir, 'SOURCE_REVIEW.md'), document);
 console.log(`Write ${outputDir}/SOURCE_REVIEW.md (${libraryNames.length} libraries, ${functions.length} functions)`);

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -13,7 +13,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 const argv = require('minimist')(process.argv.slice(2));
 
 const inputDirs = argv._[0] && argv._[0].split(',');
@@ -92,14 +91,6 @@ if (errors.length) {
 // The document. Everything in it is derived from this build: no content is
 // maintained by hand, and it is aimed at whoever reviews the package, so it
 // carries only what is needed to get from minified code to its source.
-function currentCommit () {
-    try {
-        return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
-    } catch (e) {
-        return null;  // not a git checkout, e.g. building from a package
-    }
-}
-
 const lines = [];
 lines.push('# Source review');
 lines.push('');
@@ -133,10 +124,5 @@ functions.sort((a, b) => a.name.localeCompare(b.name)).forEach(f => {
     lines.push(`| \`${f.name}\` | ${maps} |`);
 });
 lines.push('');
-const commit = currentCommit();
-if (commit) {
-    lines.push(`Built from commit \`${commit}\`.`);
-}
-
 fs.writeFileSync(path.join(outputDir, 'SOURCE_REVIEW.md'), lines.join('\n'));
 console.log(`Write ${outputDir}/SOURCE_REVIEW.md (${libraryNames.length} libraries, ${functions.length} functions)`);

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+// Build the source review index for the native app package and verify that
+// every JavaScript library inlined into modules.sql ships a source map.
+//
+// Snowflake's Native App security scan requires all app code to be
+// un-obfuscated. Minified JavaScript is allowed only when the package includes
+// a corresponding source map that recovers the un-minified code, so this script
+// both documents the correspondence for the reviewer and fails the build when a
+// map is missing.
+
+// ./build_source_review.js modules --output=build --libs_build_dir=../libraries/javascript/build
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+const argv = require('minimist')(process.argv.slice(2));
+
+const inputDirs = argv._[0] && argv._[0].split(',');
+const outputDir = argv.output || 'build';
+const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
+const sourceMapsDir = argv.source_maps_dir || 'source_review';
+
+// Extract the functions, keeping the placeholders unresolved so the libraries
+// each function inlines can be identified (build_modules.js resolves them).
+const functions = [];
+for (let inputDir of inputDirs) {
+    const sqldir = path.join(inputDir, 'sql');
+    const modules = fs.readdirSync(sqldir);
+    modules.forEach(module => {
+        const moduledir = path.join(sqldir, module);
+        if (fs.statSync(moduledir).isDirectory()) {
+            const files = fs.readdirSync(moduledir);
+            files.forEach(file => {
+                if (file.endsWith('.sql')) {
+                    const name = path.parse(file).name;
+                    const content = fs.readFileSync(path.join(moduledir, file)).toString();
+                    const libraries = [... new Set(content.match(/@@SF_LIBRARY_[A-Z0-9_]+@@/g) || [])]
+                        .map(l => l.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase());
+                    if (libraries.length && !functions.some(f => f.name === name)) {
+                        functions.push({ name, module, libraries });
+                    }
+                }
+            });
+        }
+    });
+}
+
+// Invert into library -> functions
+const libraries = {};
+functions.forEach(f => {
+    f.libraries.forEach(library => {
+        libraries[library] = libraries[library] || [];
+        libraries[library].push(f.name);
+    });
+});
+
+// Collect the built artifacts and check every library ships a usable map
+const errors = [];
+const entries = Object.keys(libraries).sort().map(library => {
+    const bundlePath = path.join(libsBuildDir, `${library}.js`);
+    const mapPath = `${bundlePath}.map`;
+    if (!fs.existsSync(bundlePath)) {
+        errors.push(`library "${library}" is inlined by ${libraries[library].join(', ')} but ${bundlePath} does not exist`);
+        return null;
+    }
+    const bundle = fs.readFileSync(bundlePath);
+    if (!bundle.toString().includes('//# sourceMappingURL=')) {
+        errors.push(`bundle "${library}.js" has no sourceMappingURL comment: enable "sourcemap" in the rollup config`);
+    }
+    if (!fs.existsSync(mapPath)) {
+        errors.push(`library "${library}" has no source map at ${mapPath}`);
+        return null;
+    }
+    const map = JSON.parse(fs.readFileSync(mapPath).toString());
+    if (!map.sourcesContent || !map.sourcesContent.length) {
+        errors.push(`source map "${library}.js.map" has no sourcesContent, so the un-minified code cannot be recovered from it`);
+    }
+    const leaked = (map.sources || []).filter(s => path.isAbsolute(s) || s.startsWith('..'));
+    if (leaked.length) {
+        errors.push(`source map "${library}.js.map" leaks build paths (${leaked[0]}): check sourcemapPathTransform`);
+    }
+    return {
+        library,
+        functions: [... new Set(libraries[library])].sort(),
+        bundleSize: bundle.length,
+        bundleSha256: crypto.createHash('sha256').update(bundle).digest('hex'),
+        mapSize: fs.statSync(mapPath).size,
+        sources: (map.sources || []).length
+    };
+});
+
+if (errors.length) {
+    errors.forEach(e => console.log(`ERROR: ${e}`));
+    process.exit(1);
+}
+
+// Build provenance, so the reviewer can reproduce the bundles rather than trust them
+function describeBuild () {
+    let commit = 'unknown';
+    try {
+        commit = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    } catch (e) {
+        // Not a git checkout (e.g. building from a package): leave it unknown
+    }
+    const dependencies = require(path.resolve(__dirname, 'package.json')).devDependencies || {};
+    const versions = ['rollup', 'rollup-plugin-terser']
+        .filter(d => dependencies[d])
+        .map(d => `${d} ${dependencies[d]}`)
+        .join(', ');
+    return { commit, versions };
+}
+
+const { commit, versions } = describeBuild();
+const totalEmbedded = entries.reduce((total, e) => total + e.bundleSize * e.functions.length, 0);
+
+const lines = [];
+lines.push('# Source review');
+lines.push('');
+lines.push('The JavaScript in `modules.sql` is minified. This package includes a source map for');
+lines.push('every library it inlines, so the un-minified code can be recovered from the map alone');
+lines.push('(`sourcesContent` is included).');
+lines.push('');
+lines.push('Snowflake JavaScript UDFs have no import mechanism: a function body must be entirely');
+lines.push('self-contained inside its `CREATE FUNCTION` statement. Each library is therefore');
+lines.push('bundled and inlined into every function that uses it, which is why one source map can');
+lines.push('cover several functions. Each inlined bundle ends with a');
+lines.push('`//# sourceMappingURL=` comment naming its map, so every occurrence is linked');
+lines.push('individually from inside the function body.');
+lines.push('');
+lines.push('## Build');
+lines.push('');
+lines.push(`- commit: \`${commit}\``);
+lines.push(`- node: \`${process.version}\``);
+if (versions) {
+    lines.push(`- bundler: \`${versions}\``);
+}
+lines.push('- command: `make deploy-native-app-package production=1`');
+lines.push('- The build is deterministic: rebuilding from this commit reproduces the bundles');
+lines.push('  byte-for-byte, so the SHA-256 values below can be verified independently.');
+lines.push('');
+lines.push(`## Libraries (${entries.length})`);
+lines.push('');
+entries.forEach(e => {
+    lines.push(`### ${e.library}`);
+    lines.push('');
+    lines.push(`- source map: \`${sourceMapsDir}/${e.library}.js.map\` (${e.mapSize.toLocaleString('en-US')} bytes, ${e.sources} original sources)`);
+    lines.push(`- inlined bundle: ${e.bundleSize.toLocaleString('en-US')} bytes, sha256 \`${e.bundleSha256}\``);
+    lines.push(`- inlined into ${e.functions.length} function(s): ${e.functions.map(f => `\`${f}\``).join(', ')}`);
+    lines.push('');
+});
+lines.push('## Functions');
+lines.push('');
+lines.push('| Function | Source map |');
+lines.push('| --- | --- |');
+functions.sort((a, b) => a.name.localeCompare(b.name)).forEach(f => {
+    const maps = f.libraries.sort().map(l => `\`${sourceMapsDir}/${l}.js.map\``).join(', ');
+    lines.push(`| \`${f.name}\` | ${maps} |`);
+});
+lines.push('');
+lines.push('## Totals');
+lines.push('');
+lines.push(`- ${entries.length} libraries inlined into ${functions.length} functions`);
+lines.push(`- ${totalEmbedded.toLocaleString('en-US')} bytes of minified JavaScript embedded in \`modules.sql\``);
+lines.push(`- ${entries.reduce((total, e) => total + e.mapSize, 0).toLocaleString('en-US')} bytes of source maps`);
+
+fs.writeFileSync(path.join(outputDir, 'SOURCE_REVIEW.md'), lines.join('\n'));
+console.log(`Write ${outputDir}/SOURCE_REVIEW.md (${entries.length} libraries, ${functions.length} functions)`);

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -12,7 +12,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const inputDirs = argv._[0] && argv._[0].split(',');
 const outputDir = argv.output || 'build';
 const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
-const sourceMapsDir = argv.source_maps_dir || 'source_review';
+const sourceMapsDir = argv.source_maps_dir || 'sourcemaps';  // keep in sync with APP_SOURCE_MAPS_DIR
 
 // Extract the functions, keeping the placeholders unresolved to identify the libraries inlined
 const functions = [];
@@ -26,7 +26,9 @@ for (let inputDir of inputDirs) {
             files.forEach(file => {
                 if (file.endsWith('.sql')) {
                     const name = path.parse(file).name;
-                    const content = fs.readFileSync(path.join(moduledir, file)).toString();
+                    // Strip SQL comments as build_modules.js and list_libraries.js do, so a
+                    // commented-out placeholder is not recorded as an inlined library
+                    const content = fs.readFileSync(path.join(moduledir, file)).toString().replace(/--.*\n/g, '');
                     const libraries = [... new Set(content.match(/@@SF_LIBRARY_[A-Z0-9_]+@@/g) || [])]
                         .map(l => l.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase());
                     if (libraries.length && !functions.some(f => f.name === name)) {
@@ -65,10 +67,17 @@ libraryNames.forEach(library => {
         return;
     }
     const map = JSON.parse(fs.readFileSync(mapPath).toString());
-    if (!map.sourcesContent || !map.sourcesContent.length) {
-        errors.push(`source map "${library}.js.map" has no sourcesContent, so the un-minified code cannot be recovered from it`);
+    // Every original must be recoverable from the map alone, which is what the index promises
+    // the reviewer: a non-empty sourcesContent is not enough if any entry is null or empty.
+    const sources = map.sources || [];
+    const contents = map.sourcesContent || [];
+    const missing = sources.filter((_, i) => typeof contents[i] !== 'string' || contents[i] === '');
+    if (contents.length !== sources.length) {
+        errors.push(`source map "${library}.js.map" has ${contents.length} sourcesContent entries for ${sources.length} sources`);
+    } else if (missing.length) {
+        errors.push(`source map "${library}.js.map" is missing the content of ${missing.length} of ${sources.length} sources, starting with "${missing[0]}"`);
     }
-    const leaked = (map.sources || []).filter(s => path.isAbsolute(s) || s.startsWith('..'));
+    const leaked = sources.filter(s => path.isAbsolute(s) || s.startsWith('..'));
     if (leaked.length) {
         errors.push(`source map "${library}.js.map" leaks build paths (${leaked[0]}): check sourcemapPathTransform`);
     }

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -11,14 +11,14 @@ const argv = require('minimist')(process.argv.slice(2));
 const inputDirs = argv._[0] && argv._[0].split(',');
 const outputDir = argv.output || 'build';
 const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
-const sourceMapsDir = argv.source_maps_dir;  // no default: APP_SOURCE_MAPS_DIR is the only source of truth
+const sourceMapsDir = argv.source_maps_dir;
 
 if (!sourceMapsDir) {
     console.log('ERROR: --source_maps_dir is required and must match APP_SOURCE_MAPS_DIR');
     process.exit(1);
 }
 
-// Extract the functions, keeping the placeholders unresolved to identify the libraries inlined
+// Extract functions and the libraries they inline
 const functions = [];
 for (let inputDir of inputDirs) {
     const sqldir = path.join(inputDir, 'sql');
@@ -30,7 +30,7 @@ for (let inputDir of inputDirs) {
             files.forEach(file => {
                 if (file.endsWith('.sql')) {
                     const name = path.parse(file).name;
-                    // Strip comments as build_modules.js does: a commented-out placeholder is not inlined
+                    // Strip comments as build_modules.js does, or a commented-out placeholder counts
                     const content = fs.readFileSync(path.join(moduledir, file)).toString().replace(/--.*\n/g, '');
                     const libraries = [... new Set(content.match(/@@SF_LIBRARY_[A-Z0-9_]+@@/g) || [])]
                         .map(l => l.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase());
@@ -51,7 +51,7 @@ functions.forEach(f => {
     });
 });
 
-// A missing or unusable map is a build failure: the package would be rejected by the security scan
+// Check the source maps
 const errors = [];
 const libraryNames = Object.keys(libraries).sort();
 libraryNames.forEach(library => {
@@ -76,7 +76,6 @@ libraryNames.forEach(library => {
         errors.push(`source map "${library}.js.map" is not valid JSON: ${e.message}`);
         return;
     }
-    // The index promises every original is recoverable from the map alone, so presence is not enough
     const sources = map.sources || [];
     const contents = map.sourcesContent || [];
     const missing = sources.filter((_, i) => typeof contents[i] !== 'string' || contents[i] === '');

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -62,7 +62,8 @@ libraryNames.forEach(library => {
         return;
     }
     if (!fs.readFileSync(bundlePath).toString().includes('//# sourceMappingURL=')) {
-        errors.push(`bundle "${library}.js" has no sourceMappingURL comment: enable "sourcemap" in the rollup config`);
+        errors.push(`bundle "${library}.js" has no sourceMappingURL comment: build the libraries with "sourcemap=1"`);
+        return;
     }
     if (!fs.existsSync(mapPath)) {
         errors.push(`library "${library}" has no source map at ${mapPath}`);

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -55,22 +55,24 @@ functions.forEach(f => {
     });
 });
 
-// Collect the built artifacts and check every library ships a usable map
+// Check that every library inlined into the SQL ships a source map the
+// un-minified code can actually be recovered from. A missing or unusable map is
+// a build failure: the package would be rejected by the security scan.
 const errors = [];
-const entries = Object.keys(libraries).sort().map(library => {
+const libraryNames = Object.keys(libraries).sort();
+libraryNames.forEach(library => {
     const bundlePath = path.join(libsBuildDir, `${library}.js`);
     const mapPath = `${bundlePath}.map`;
     if (!fs.existsSync(bundlePath)) {
         errors.push(`library "${library}" is inlined by ${libraries[library].join(', ')} but ${bundlePath} does not exist`);
-        return null;
+        return;
     }
-    const bundle = fs.readFileSync(bundlePath);
-    if (!bundle.toString().includes('//# sourceMappingURL=')) {
+    if (!fs.readFileSync(bundlePath).toString().includes('//# sourceMappingURL=')) {
         errors.push(`bundle "${library}.js" has no sourceMappingURL comment: enable "sourcemap" in the rollup config`);
     }
     if (!fs.existsSync(mapPath)) {
         errors.push(`library "${library}" has no source map at ${mapPath}`);
-        return null;
+        return;
     }
     const map = JSON.parse(fs.readFileSync(mapPath).toString());
     if (!map.sourcesContent || !map.sourcesContent.length) {
@@ -80,10 +82,6 @@ const entries = Object.keys(libraries).sort().map(library => {
     if (leaked.length) {
         errors.push(`source map "${library}.js.map" leaks build paths (${leaked[0]}): check sourcemapPathTransform`);
     }
-    return {
-        library,
-        functions: [... new Set(libraries[library])].sort()
-    };
 });
 
 if (errors.length) {
@@ -135,18 +133,10 @@ functions.sort((a, b) => a.name.localeCompare(b.name)).forEach(f => {
     lines.push(`| \`${f.name}\` | ${maps} |`);
 });
 lines.push('');
-lines.push('## Libraries');
-lines.push('');
-lines.push('| Library | Source map | Functions inlining it |');
-lines.push('| --- | --- | --- |');
-entries.forEach(e => {
-    lines.push(`| ${e.library} | \`${sourceMapsDir}/${e.library}.js.map\` | ${e.functions.length} |`);
-});
-lines.push('');
 const commit = currentCommit();
 if (commit) {
     lines.push(`Built from commit \`${commit}\`.`);
 }
 
 fs.writeFileSync(path.join(outputDir, 'SOURCE_REVIEW.md'), lines.join('\n'));
-console.log(`Write ${outputDir}/SOURCE_REVIEW.md (${entries.length} libraries, ${functions.length} functions)`);
+console.log(`Write ${outputDir}/SOURCE_REVIEW.md (${libraryNames.length} libraries, ${functions.length} functions)`);

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 
-// Build the source review index for the native app package and verify that
-// every JavaScript library inlined into modules.sql ships a source map.
-//
-// Snowflake's Native App security scan requires all app code to be
-// un-obfuscated. Minified JavaScript is allowed only when the package includes
-// a corresponding source map that recovers the un-minified code, so this script
-// both documents the correspondence for the reviewer and fails the build when a
-// map is missing.
+// Build the source review index for the native app package
+// and check every inlined library ships a usable source map
 
 // ./build_source_review.js modules --output=build --libs_build_dir=../libraries/javascript/build
 
@@ -20,8 +14,7 @@ const outputDir = argv.output || 'build';
 const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
 const sourceMapsDir = argv.source_maps_dir || 'source_review';
 
-// Extract the functions, keeping the placeholders unresolved so the libraries
-// each function inlines can be identified (build_modules.js resolves them).
+// Extract the functions, keeping the placeholders unresolved to identify the libraries inlined
 const functions = [];
 for (let inputDir of inputDirs) {
     const sqldir = path.join(inputDir, 'sql');
@@ -54,9 +47,7 @@ functions.forEach(f => {
     });
 });
 
-// Check that every library inlined into the SQL ships a source map the
-// un-minified code can actually be recovered from. A missing or unusable map is
-// a build failure: the package would be rejected by the security scan.
+// A missing or unusable map is a build failure: the package would be rejected by the security scan
 const errors = [];
 const libraryNames = Object.keys(libraries).sort();
 libraryNames.forEach(library => {
@@ -88,9 +79,7 @@ if (errors.length) {
     process.exit(1);
 }
 
-// The document. Everything in it is derived from this build: no content is
-// maintained by hand, and it is aimed at whoever reviews the package, so it
-// carries only what is needed to get from minified code to its source.
+// The document, derived entirely from this build and aimed at whoever reviews the package
 const lines = [];
 lines.push('# Source review');
 lines.push('');

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -3,7 +3,7 @@
 // Build the source review index for the native app package
 // and check every inlined library ships a usable source map
 
-// ./build_source_review.js modules --output=build --libs_build_dir=../libraries/javascript/build
+// ./build_source_review.js modules --output=build --libs_build_dir=../libraries/javascript/build --source_maps_dir=sourcemaps
 
 const fs = require('fs');
 const path = require('path');
@@ -12,7 +12,12 @@ const argv = require('minimist')(process.argv.slice(2));
 const inputDirs = argv._[0] && argv._[0].split(',');
 const outputDir = argv.output || 'build';
 const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
-const sourceMapsDir = argv.source_maps_dir || 'sourcemaps';  // keep in sync with APP_SOURCE_MAPS_DIR
+const sourceMapsDir = argv.source_maps_dir;  // no default: APP_SOURCE_MAPS_DIR is the only source of truth
+
+if (!sourceMapsDir) {
+    console.log('ERROR: --source_maps_dir is required and must match APP_SOURCE_MAPS_DIR');
+    process.exit(1);
+}
 
 // Extract the functions, keeping the placeholders unresolved to identify the libraries inlined
 const functions = [];

--- a/clouds/snowflake/common/build_source_review.js
+++ b/clouds/snowflake/common/build_source_review.js
@@ -66,13 +66,23 @@ libraryNames.forEach(library => {
         errors.push(`library "${library}" has no source map at ${mapPath}`);
         return;
     }
-    const map = JSON.parse(fs.readFileSync(mapPath).toString());
+    let map;
+    try {
+        map = JSON.parse(fs.readFileSync(mapPath).toString());
+    } catch (e) {
+        // Report it rather than dying with a raw parse error, so the build failure names the file
+        errors.push(`source map "${library}.js.map" is not valid JSON: ${e.message}`);
+        return;
+    }
     // Every original must be recoverable from the map alone, which is what the index promises
-    // the reviewer: a non-empty sourcesContent is not enough if any entry is null or empty.
+    // the reviewer. A non-empty sourcesContent is not enough: a map with no sources at all, or
+    // with null entries, recovers nothing while still satisfying a presence check.
     const sources = map.sources || [];
     const contents = map.sourcesContent || [];
     const missing = sources.filter((_, i) => typeof contents[i] !== 'string' || contents[i] === '');
-    if (contents.length !== sources.length) {
+    if (!sources.length) {
+        errors.push(`source map "${library}.js.map" lists no sources, so no original can be recovered from it`);
+    } else if (contents.length !== sources.length) {
         errors.push(`source map "${library}.js.map" has ${contents.length} sourcesContent entries for ${sources.length} sources`);
     } else if (missing.length) {
         errors.push(`source map "${library}.js.map" is missing the content of ${missing.length} of ${sources.length} sources, starting with "${missing[0]}"`);

--- a/clouds/snowflake/common/rollup.config.js
+++ b/clouds/snowflake/common/rollup.config.js
@@ -30,7 +30,7 @@ export default {
     input,
     output: {
         file: process.env.OUTPUT,
-        sourcemap: Boolean(process.env.SOURCEMAP),
+        sourcemap: process.env.SOURCEMAP === '1',
         sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
             // Re-root sources at the repo directory: the defaults are relative to the map and leak the build layout
             const absolutePath = path.resolve(path.dirname(sourcemapPath), relativeSourcePath);

--- a/clouds/snowflake/common/rollup.config.js
+++ b/clouds/snowflake/common/rollup.config.js
@@ -32,7 +32,7 @@ export default {
         file: process.env.OUTPUT,
         sourcemap: process.env.SOURCEMAP === '1',
         sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
-            // Re-root sources at the repo directory: the defaults are relative to the map and leak the build layout
+            // Re-root sources: the defaults leak the build layout
             const absolutePath = path.resolve(path.dirname(sourcemapPath), relativeSourcePath);
             const marker = `${path.sep}clouds${path.sep}`;
             const index = absolutePath.lastIndexOf(marker);

--- a/clouds/snowflake/common/rollup.config.js
+++ b/clouds/snowflake/common/rollup.config.js
@@ -30,6 +30,22 @@ export default {
     input,
     output: {
         file: process.env.OUTPUT,
+        sourcemap: true,
+        sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
+            // Source paths default to being relative to the map, which is
+            // meaningless once the map ships in its own package sub-directory
+            // (and leaks the build machine's layout when building out of tree).
+            // Re-root them at the repository directory instead, so a reviewer
+            // reading the map sees where each source actually lives.
+            const absolutePath = path.resolve(path.dirname(sourcemapPath), relativeSourcePath);
+            const marker = `${path.sep}clouds${path.sep}`;
+            const index = absolutePath.lastIndexOf(marker);
+            if (index === -1) {
+                return relativeSourcePath;
+            }
+            const root = absolutePath.slice(0, index).split(path.sep).pop();
+            return [root, ...absolutePath.slice(index + 1).split(path.sep)].join('/');
+        },
         format: process.env.UNIT_TEST ? 'umd': 'iife',
         name: process.env.UNIT_TEST ? name : '_' + name,
         banner: process.env.UNIT_TEST ? '' : 'if (typeof(' +name +') === "undefined") {',

--- a/clouds/snowflake/common/rollup.config.js
+++ b/clouds/snowflake/common/rollup.config.js
@@ -30,7 +30,7 @@ export default {
     input,
     output: {
         file: process.env.OUTPUT,
-        sourcemap: true,
+        sourcemap: Boolean(process.env.SOURCEMAP),
         sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
             // Source paths default to being relative to the map, which is
             // meaningless once the map ships in its own package sub-directory

--- a/clouds/snowflake/common/rollup.config.js
+++ b/clouds/snowflake/common/rollup.config.js
@@ -32,11 +32,7 @@ export default {
         file: process.env.OUTPUT,
         sourcemap: Boolean(process.env.SOURCEMAP),
         sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
-            // Source paths default to being relative to the map, which is
-            // meaningless once the map ships in its own package sub-directory
-            // (and leaks the build machine's layout when building out of tree).
-            // Re-root them at the repository directory instead, so a reviewer
-            // reading the map sees where each source actually lives.
+            // Re-root sources at the repo directory: the defaults are relative to the map and leak the build layout
             const absolutePath = path.resolve(path.dirname(sourcemapPath), relativeSourcePath);
             const marker = `${path.sep}clouds${path.sep}`;
             const index = absolutePath.lastIndexOf(marker);

--- a/clouds/snowflake/libraries/javascript/Makefile
+++ b/clouds/snowflake/libraries/javascript/Makefile
@@ -51,6 +51,7 @@ ifdef UNIT_TEST
 	$(COMMON_DIR)/list_libraries.js $(MODULES_DIR) --all 1>/dev/null # Check errors
 	for f in `$(COMMON_DIR)/list_libraries.js $(MODULES_DIR) --all`; do \
 		NAME=$${f}Lib \
+		SOURCEMAP=$(sourcemap) \
 		PATH="$(NODE_MODULES_DEV)/.bin/:$(PATH)" \
 		DIRS=$(LIBS_DIR) \
 		FILENAME=$${f}.js \
@@ -61,6 +62,7 @@ else
 	$(COMMON_DIR)/list_libraries.js $(MODULES_DIRS) --diff="$(diff)" --modules=$(modules) --functions=$(functions) --nodeps=$(nodeps) 1>/dev/null # Check errors
 	for f in `$(COMMON_DIR)/list_libraries.js $(MODULES_DIRS) --diff="$(diff)" --modules=$(modules) --functions=$(functions) --nodeps=$(nodeps)`; do \
 		NAME=$${f}Lib \
+		SOURCEMAP=$(sourcemap) \
 		PATH="$(NODE_MODULES_DEV)/.bin/:$(PATH)" \
 		DIRS=$(LIBS_DIRS) \
 		FILENAME=$${f}.js \

--- a/clouds/snowflake/modules/Makefile
+++ b/clouds/snowflake/modules/Makefile
@@ -88,6 +88,7 @@ build-share: $(NODE_MODULES_DEV)
 
 build-source-review: $(NODE_MODULES_DEV)
 	echo "Building source review..."
+	mkdir -p $(BUILD_DIR)
 	$(COMMON_DIR)/build_source_review.js $(MODULES_DIRS) \
 		--output=$(BUILD_DIR) --libs_build_dir=$(LIBS_BUILD_DIR) \
 		--source_maps_dir=$(APP_SOURCE_MAPS_DIR)

--- a/clouds/snowflake/modules/Makefile
+++ b/clouds/snowflake/modules/Makefile
@@ -34,7 +34,7 @@ include $(COMMON_DIR)/Makefile
 
 .SILENT:
 
-.PHONY: help lint lint-fix build build-share build-native-app-setup-script deploy deploy-share test test-fast test-slow benchmark remove remove-share clean
+.PHONY: help lint lint-fix build build-share build-source-review build-native-app-setup-script deploy deploy-share test test-fast test-slow benchmark remove remove-share clean
 
 help:
 	echo "Available targets: lint build deploy test benchmark remove clean"
@@ -85,6 +85,12 @@ build-share: $(NODE_MODULES_DEV)
 	$(COMMON_DIR)/build_share.js $(MODULES_DIRS) \
 		--output=$(BUILD_DIR) --libs_build_dir=$(LIBS_BUILD_DIR) --diff="$(diff)" \
 		--modules=$(modules) --functions=$(functions) --production=$(production) --nodeps=$(nodeps) --dropfirst=$(dropfirst)
+
+build-source-review: $(NODE_MODULES_DEV)
+	echo "Building source review..."
+	$(COMMON_DIR)/build_source_review.js $(MODULES_DIRS) \
+		--output=$(BUILD_DIR) --libs_build_dir=$(LIBS_BUILD_DIR) \
+		--source_maps_dir=$(APP_SOURCE_MAPS_DIR)
 
 build-native-app-setup-script: $(NODE_MODULES_DEV)
 	echo "Building native app setup script..."

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -52,6 +52,10 @@ check-package-sourcemaps:
 	test -n "$$maps" || { echo "ERROR: modules.sql references no source map at all"; exit 1; }; \
 	for map in $$maps; do \
 		test -f $$pkg/$$map || { echo "ERROR: modules.sql references $$map, which is not in the package"; exit 1; }; \
+	done; \
+	for f in $$pkg/$(APP_SOURCE_MAPS_DIR)/*.js.map; do \
+		rel=$(APP_SOURCE_MAPS_DIR)/`basename $$f`; \
+		echo "$$maps" | grep -qx "$$rel" || { echo "ERROR: $$rel ships in the package but nothing references it"; exit 1; }; \
 	done
 
 deploy-app-package:

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -46,7 +46,6 @@ build:
 	$(MAKE) check-package-sourcemaps
 
 
-# A wrong prefix or a half-applied rename still builds, so check the references resolve
 check-package-sourcemaps:
 	set -e; pkg=$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME); \
 	maps=`grep -o '//# sourceMappingURL=[^ ]*' $$pkg/modules.sql | sed 's|.*=||' | sort -u`; \
@@ -57,10 +56,9 @@ check-package-sourcemaps:
 
 deploy-app-package:
 	$(COMMON_DIR)/run-query.js "CREATE STAGE IF NOT EXISTS $(APP_STAGE_NAME);"
-# PUT overwrites but never deletes, and non-production builds share one stage prefix, so a
-# renamed or dropped library would leave an orphan map to be snapshotted into the next patch
+# PUT never deletes and non-production builds share one stage prefix, so drop stale maps first
 	$(COMMON_DIR)/run-query.js "REMOVE @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR);"
-# PUT cannot upload directories, so this glob takes files only and the next statement the maps
+# *.* takes files only: PUT cannot upload the maps directory, so it goes in the next statement
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/*.* @$(APP_STAGE_LOCATION) overwrite=true auto_compress=false;"
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)/* @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR) overwrite=true auto_compress=false;"
 

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -6,6 +6,7 @@ DIST_DIR ?= $(ROOT_DIR)/../dist
 ENV_DIR ?= $(ROOT_DIR)/..
 BUILD_DIR ?= $(ROOT_DIR)/../build
 COMMON_DIR = $(ROOT_DIR)/../common
+LIBS_BUILD_DIR ?= $(BUILD_DIR)/../libraries/javascript/build
 APP_DIR ?= $(ROOT_DIR)
 
 include $(COMMON_DIR)/Makefile
@@ -39,11 +40,18 @@ build:
 	sed 's/@@VERSION@@/$(APP_VERSION)/g' $(APP_DIR)/manifest.yml > $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/manifest.yml
 	cp $(APP_DIR)/README.md $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/
 	cp $(APP_DIR)/get_modules_sql_from_stage.py $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/
+	cp $(BUILD_DIR)/SOURCE_REVIEW.md $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/
+	mkdir -p $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)
+	cp $(LIBS_BUILD_DIR)/*.js.map $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)/
 
 
 deploy-app-package:
 	$(COMMON_DIR)/run-query.js "CREATE STAGE IF NOT EXISTS $(APP_STAGE_NAME);"
-	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/* @$(APP_STAGE_LOCATION) overwrite=true auto_compress=false;"
+# PUT cannot upload directories and does not recurse, so this glob deliberately
+# matches files only (every package file has an extension) and the source maps
+# sub-directory is uploaded by the statement below.
+	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/*.* @$(APP_STAGE_LOCATION) overwrite=true auto_compress=false;"
+	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)/* @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR) overwrite=true auto_compress=false;"
 
 	result=$$(CHECK_APP_PACKAGE_EXISTENCE=1 APP_PACKAGE_NAME=$(APP_PACKAGE_NAME) $(COMMON_DIR)/native-app-utils.js) && \
 	if [ $${result} -eq 0 ]; then \

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -6,8 +6,8 @@ DIST_DIR ?= $(ROOT_DIR)/../dist
 ENV_DIR ?= $(ROOT_DIR)/..
 BUILD_DIR ?= $(ROOT_DIR)/../build
 COMMON_DIR = $(ROOT_DIR)/../common
-LIBS_BUILD_DIR ?= $(APP_DIR)/../libraries/javascript/build
 APP_DIR ?= $(ROOT_DIR)
+LIBS_BUILD_DIR ?= $(APP_DIR)/../libraries/javascript/build
 
 include $(COMMON_DIR)/Makefile
 

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -6,7 +6,7 @@ DIST_DIR ?= $(ROOT_DIR)/../dist
 ENV_DIR ?= $(ROOT_DIR)/..
 BUILD_DIR ?= $(ROOT_DIR)/../build
 COMMON_DIR = $(ROOT_DIR)/../common
-LIBS_BUILD_DIR ?= $(BUILD_DIR)/../libraries/javascript/build
+LIBS_BUILD_DIR ?= $(APP_DIR)/../libraries/javascript/build
 APP_DIR ?= $(ROOT_DIR)
 
 include $(COMMON_DIR)/Makefile

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -27,7 +27,7 @@ endif
 
 .SILENT:
 
-.PHONY: help build deploy-app-package deploy-app drop-app-package drop-app
+.PHONY: help build check-package-sourcemaps deploy-app-package deploy-app drop-app-package drop-app
 
 help:
 	echo "Available targets: help build deploy-app-package deploy-app drop-app-package drop-app"
@@ -43,7 +43,15 @@ build:
 	cp $(BUILD_DIR)/SOURCE_REVIEW.md $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/
 	mkdir -p $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)
 	cp $(LIBS_BUILD_DIR)/*.js.map $(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)/
+	$(MAKE) check-package-sourcemaps
 
+
+# A wrong prefix or a half-applied rename still builds, so check the references resolve
+check-package-sourcemaps:
+	set -e; pkg=$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME); \
+	for map in `grep -o '//# sourceMappingURL=[^ ]*' $$pkg/modules.sql | sed 's|.*=||' | sort -u`; do \
+		test -f $$pkg/$$map || { echo "ERROR: modules.sql references $$map, which is not in the package"; exit 1; }; \
+	done
 
 deploy-app-package:
 	$(COMMON_DIR)/run-query.js "CREATE STAGE IF NOT EXISTS $(APP_STAGE_NAME);"

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -49,12 +49,17 @@ build:
 # A wrong prefix or a half-applied rename still builds, so check the references resolve
 check-package-sourcemaps:
 	set -e; pkg=$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME); \
-	for map in `grep -o '//# sourceMappingURL=[^ ]*' $$pkg/modules.sql | sed 's|.*=||' | sort -u`; do \
+	maps=`grep -o '//# sourceMappingURL=[^ ]*' $$pkg/modules.sql | sed 's|.*=||' | sort -u`; \
+	test -n "$$maps" || { echo "ERROR: modules.sql references no source map at all"; exit 1; }; \
+	for map in $$maps; do \
 		test -f $$pkg/$$map || { echo "ERROR: modules.sql references $$map, which is not in the package"; exit 1; }; \
 	done
 
 deploy-app-package:
 	$(COMMON_DIR)/run-query.js "CREATE STAGE IF NOT EXISTS $(APP_STAGE_NAME);"
+# PUT overwrites but never deletes, and non-production builds share one stage prefix, so a
+# renamed or dropped library would leave an orphan map to be snapshotted into the next patch
+	$(COMMON_DIR)/run-query.js "REMOVE @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR);"
 # PUT cannot upload directories, so this glob takes files only and the next statement the maps
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/*.* @$(APP_STAGE_LOCATION) overwrite=true auto_compress=false;"
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)/* @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR) overwrite=true auto_compress=false;"

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -47,9 +47,7 @@ build:
 
 deploy-app-package:
 	$(COMMON_DIR)/run-query.js "CREATE STAGE IF NOT EXISTS $(APP_STAGE_NAME);"
-# PUT cannot upload directories and does not recurse, so this glob deliberately
-# matches files only (every package file has an extension) and the source maps
-# sub-directory is uploaded by the statement below.
+# PUT cannot upload directories, so this glob takes files only and the next statement the maps
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/*.* @$(APP_STAGE_LOCATION) overwrite=true auto_compress=false;"
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)/* @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR) overwrite=true auto_compress=false;"
 

--- a/clouds/snowflake/native_app/Makefile
+++ b/clouds/snowflake/native_app/Makefile
@@ -58,7 +58,7 @@ deploy-app-package:
 	$(COMMON_DIR)/run-query.js "CREATE STAGE IF NOT EXISTS $(APP_STAGE_NAME);"
 # PUT never deletes and non-production builds share one stage prefix, so drop stale maps first
 	$(COMMON_DIR)/run-query.js "REMOVE @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR);"
-# *.* takes files only: PUT cannot upload the maps directory, so it goes in the next statement
+# *.* takes files only: PUT cannot upload a directory
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/*.* @$(APP_STAGE_LOCATION) overwrite=true auto_compress=false;"
 	$(COMMON_DIR)/run-query.js "PUT file://$(DIST_DIR)/$(APP_PACKAGE_DIST_NAME)/$(APP_SOURCE_MAPS_DIR)/* @$(APP_STAGE_LOCATION)/$(APP_SOURCE_MAPS_DIR) overwrite=true auto_compress=false;"
 

--- a/clouds/snowflake/native_app/README.md
+++ b/clouds/snowflake/native_app/README.md
@@ -67,6 +67,15 @@ CALL CARTO.CARTO.INSTALL('CARTO_ANALYTICS_TOOLBOX', 'CARTO.CARTO');
 
 If your Analytics Toolbox doesn't get updated properly please try to drop the app, get it back from Snowflake Marketplace and follow the Step 1.
 
+### Source code and source maps
+
+The JavaScript in `modules.sql` is minified. This package ships a source map for every library it
+inlines, under `sourcemaps/`, each including `sourcesContent` so the original un-minified source can
+be recovered from the map alone. Every inlined bundle ends with a `//# sourceMappingURL=` comment
+naming its map.
+
+`SOURCE_REVIEW.md` at the package root lists which map covers which function.
+
 ### Usage Examples
 
 Please refer to CARTO's [SQL reference](https://docs.carto.com/data-and-analysis/analytics-toolbox-for-snowflake/sql-reference) to find the full list of available functions and procedures as well as examples.

--- a/clouds/snowflake/native_app/README.md
+++ b/clouds/snowflake/native_app/README.md
@@ -67,15 +67,6 @@ CALL CARTO.CARTO.INSTALL('CARTO_ANALYTICS_TOOLBOX', 'CARTO.CARTO');
 
 If your Analytics Toolbox doesn't get updated properly please try to drop the app, get it back from Snowflake Marketplace and follow the Step 1.
 
-### Source code and source maps
-
-The JavaScript in `modules.sql` is minified. This package ships a source map for every library it
-inlines, under `sourcemaps/`, each including `sourcesContent` so the original un-minified source can
-be recovered from the map alone. Every inlined bundle ends with a `//# sourceMappingURL=` comment
-naming its map.
-
-`SOURCE_REVIEW.md` at the package root lists which map covers which function.
-
 ### Usage Examples
 
 Please refer to CARTO's [SQL reference](https://docs.carto.com/data-and-analysis/analytics-toolbox-for-snowflake/sql-reference) to find the full list of available functions and procedures as well as examples.


### PR DESCRIPTION
## Why

Patch 27 of the Snowflake Native App package (AT v1.26.2) was **rejected** by Snowflake's automated security scan:

> Application code includes minified Javascript code. Snowflake security policy requires all application code to be un-obfuscated, meaning that the code must be human readable. This requirement includes minified JavaScript code.

Nothing changed on our side — `terser()` has been in this rollup chain since 2022 (`8e7f813d`), and both the accepted patch 26 and the rejected patch 27 inline the same set of libraries. Snowflake's [security requirements](https://docs.snowflake.com/en/developer-guide/native-apps/security-app-requirements) document the compliant path:

> If an app needs to use minified JavaScript code, it must include a corresponding source map file that can be used to recover the un-minified code.

and Snowflake support then asked for:

> the `.js.map` naming convention, and as far as possible name the file(s) in a way that makes it easy to map to the files (and if applicable, functions) where you use the minified js

The alternative is the appeal process — one appeal per patch, 3-5 business days, no carryover — which does not work against a monthly release cadence. **Installed functions stay minified**; we ship maps so the un-minified source is recoverable.

## What changes

**`common/rollup.config.js`** — emits a source map per library. `sourcesContent` is kept, so the un-minified code is recoverable from the map alone. `sourcemapPathTransform` re-roots the source paths at the repository directory (`analytics-toolbox/clouds/snowflake/…`, `core/clouds/snowflake/…`) instead of leaking the build machine's layout.

**`common/build_source_review.js`** (new) — generates `SOURCE_REVIEW.md` and validates the result. Snowflake JS UDFs have no import mechanism, so each library is inlined into every function that uses it: 39 libraries across 96 functions, `data_enrichment` alone into 17. One map therefore covers several functions, so the index answers the question a reviewer actually has — *given this function, where is its source* — as a `function → map` table:

```
| Function | Source map |
| --- | --- |
| `_GET_HISTOGRAM_NBINS` | `sourcemaps/statistics.js.map` |
| `_LINEAR_REGRESSION`   | `sourcemaps/statistics.js.map` |
```

An earlier revision also carried per-library sizes, bundle SHA-256s and build provenance. Those were removed deliberately after review of the customer-facing version: in-package hashes are self-referential, and the reproducibility they supported does not work for a reviewer who cannot rebuild a private repo. The document is now the review path and nothing else.

**The same script is the guard.** It fails the build when an inlined library has no map, when a map cannot yield every one of its originals (no sources at all, a length mismatch, or any null/empty entry), when a map is not valid JSON, when a bundle has no `sourceMappingURL`, or when a map leaks build paths. `--source_maps_dir` is required rather than defaulted, so `APP_SOURCE_MAPS_DIR` is the only place the directory is named. Without it a future release could silently ship unmapped JavaScript and be rejected again — and it earned its keep immediately: it caught my first `sourcemapPathTransform`, which worked out-of-tree but was a no-op under the real build.

**Makefiles** — `sourcemaps/` in the package, the `sourceMappingURL` prefix applied before the bundles are inlined, and a second `PUT` for the sub-directory.

## Package shape

```
manifest.yml, README.md, setup_script.sql, get_modules_sql_from_stage.py   unchanged
modules.sql          minified as before + //# sourceMappingURL=sourcemaps/<lib>.js.map
SOURCE_REVIEW.md     the index (kept at the root so a reviewer finds it)
sourcemaps/       39 × <lib>.js.map
```

The shipped SQL is otherwise unchanged: the only difference inside each function body is the trailing comment.

## Verification

Built the premium package end to end (`make build-native-app-setup-script` + `make -C native_app build`):

- 39 maps present, `sourcesContent` included, paths re-rooted, **no** absolute or `..` leaks
- 139 `sourceMappingURL` comments in `modules.sql`, all resolved to `sourcemaps/`
- the three tiler UDTFs that inline a placeholder **mid-line** (`_GEOJSON_TO_MVT_TILE`, `_GEOJSON_TO_BINARY_TILE`, `_GEOJSON_TO_BINARY_SPATIAL_INDEX_TILE`) still parse — rollup emits a newline after the comment, so the following `},` lands on its own line
- both `PUT` statements resolve correctly (`make -n`)
- library test suites pass: core 13/13, premium 16/16 (179 tests) — the `UNIT_TEST` umd build is unaffected
- `make lint` clean in core

## Two things for the reviewer

**1. The first `PUT` glob changed from `/*` to `/*.*`.** `PUT` cannot upload directories and does not recurse, so the original glob would now also match `sourcemaps/`. `*.*` matches files only — all six package files have extensions — and the sub-directory gets its own statement. Flagging it because it is the one behaviour that cannot be verified without a real stage, and because an extension-less package file added later would be silently skipped. It now carries a comment saying so, because tidying it to `*` would break the upload. Happy to switch to explicit per-file statements if you prefer.

**2. Package size.** The premium package goes to ~11 MB (4.5 MB `modules.sql` + ~7 MB of maps). No documented size limit for a version's files was found, but it is a real jump. If it becomes a problem, `sourcemapExcludeSources` cuts the maps by ~70% — at the cost of no longer satisfying "recover the un-minified code" from the map alone.

## Rollout

- This does not take effect for the premium package until AT bumps the submodule — **deliberately not included here**, per the convention of keeping the bump separate.
- **Already validated in production.** Patch 28 of the premium package was built from this branch and submitted, and Snowflake's scan **approved it automatically** — no appeal spent. That answers the open question this PR was originally written against: the scan does resolve `//# sourceMappingURL=` out of JavaScript embedded in a `.sql` file, and it follows the relative `sourcemaps/` sub-path. Snowflake also confirmed in writing that files in the version root which the manifest does not declare travel with the app but are not readable by consumers.
- The layout stays one variable (`APP_SOURCE_MAPS_DIR`) and one `sed`, if Snowflake ever wants a different arrangement.

Story: sc-571986

🤖 Generated with [Claude Code](https://claude.com/claude-code)

