### PR TITLE
fix(sf,pg,ora,bq): insert every replacement literally when building SQL [sc-572077]

### DIFF
--- a/clouds/bigquery/common/build_modules.js
+++ b/clouds/bigquery/common/build_modules.js
@@ -171,7 +171,7 @@ const outputSeparator = argv.production ? '\n' : internalSeparator;
 let content = output.map(f => f.content).join(internalSeparator);
 
 function apply_replacements (text) {
-    const libraries = [... new Set(content.match(new RegExp('@@BQ_LIBRARY_[^@]*?_BUCKET@@', 'g')))];
+    const libraries = [... new Set(text.match(new RegExp('@@BQ_LIBRARY_[^@]*?_BUCKET@@', 'g')))];
     for (let library of libraries) {
         let libraryName = library.replace('@@BQ_LIBRARY_', '').replace('_BUCKET@@', '').toLowerCase();
         if (makelib == libraryName) {
@@ -181,7 +181,7 @@ function apply_replacements (text) {
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryBucketPath = libraryBucket + '_' + libraryName;
-            text = text.replace(new RegExp(library, 'g'), libraryBucketPath);
+            text = text.replace(new RegExp(library, 'g'), () => libraryBucketPath);
         }
         else {
             console.log(`Warning: library "${libraryName}" does not exist. Run "make build-libraries" with the same filters.`);
@@ -192,7 +192,7 @@ function apply_replacements (text) {
     for (let replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     text = text.replace(/@@SKIP_DEP@@/g, '');

--- a/clouds/bigquery/common/run-script.js
+++ b/clouds/bigquery/common/run-script.js
@@ -22,7 +22,7 @@ function apply_replacements (text) {
         for (let replacement of replacements) {
             if (replacement) {
                 const pattern = new RegExp(`@@${replacement}@@`, 'g');
-                text = text.replace(pattern, process.env[replacement]);
+                text = text.replace(pattern, () => process.env[replacement]);
             }
         }
     }

--- a/clouds/databricks/common/build_modules.js
+++ b/clouds/databricks/common/build_modules.js
@@ -164,7 +164,7 @@ function apply_replacements (text) {
     for (let replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     text = text.replace(/\\`/g, '`');

--- a/clouds/oracle/common/build_modules.js
+++ b/clouds/oracle/common/build_modules.js
@@ -210,8 +210,7 @@ function apply_replacements (text) {
             );
             process.exit(1);
         }
-        // A replacer function, so $&, $` and $' inside a bundle are inserted
-        // literally instead of being expanded as replacement patterns.
+        // A replacer function, so $&, $` and $' in a bundle are inserted literally
         const libraryContent = fs.readFileSync(file).toString();
         text = text.replace(new RegExp(library, 'g'), () => libraryContent);
     }

--- a/clouds/oracle/common/build_modules.js
+++ b/clouds/oracle/common/build_modules.js
@@ -210,10 +210,10 @@ function apply_replacements (text) {
             );
             process.exit(1);
         }
-        text = text.replace(
-            new RegExp(library, 'g'),
-            fs.readFileSync(file).toString()
-        );
+        // A replacer function, so $&, $` and $' inside a bundle are inserted
+        // literally instead of being expanded as replacement patterns.
+        const libraryContent = fs.readFileSync(file).toString();
+        text = text.replace(new RegExp(library, 'g'), () => libraryContent);
     }
     const replacements = process.env.REPLACEMENTS.split(' ');
     for (const replacement of replacements) {

--- a/clouds/oracle/common/build_modules.js
+++ b/clouds/oracle/common/build_modules.js
@@ -212,7 +212,7 @@ function apply_replacements (text) {
     const libraryDir = path.resolve(
         __dirname, '..', 'libraries', 'javascript', 'build'
     );
-    const libraries = [...new Set(text.match(/@@ORA_LIBRARY_[A-Z0-9_]+@@/g) || [])];
+    const libraries = [...new Set(text.match(/@@ORA_LIBRARY_[^@]+@@/g) || [])];
     for (const library of libraries) {
         const libName = library.replace('@@ORA_LIBRARY_', '').replace('@@', '');
         const file = path.join(libraryDir, libName.toLowerCase() + '.js');

--- a/clouds/oracle/common/build_modules.js
+++ b/clouds/oracle/common/build_modules.js
@@ -195,6 +195,19 @@ let content = output.map(f => f.content).join('\n');
 
 // Inline @@ORA_LIBRARY_<NAME>@@ → libraries/javascript/build/<name>.js, then
 // apply env-var @@VAR@@ replacements.
+// Guards against a future revert to a string replacement, where $& and $$ would expand
+function insert_literally (text, placeholder, content) {
+    const pattern = new RegExp(placeholder, 'g');
+    const count = (text.match(pattern) || []).length;
+    const expected = text.length + count * (content.length - placeholder.length);
+    const result = text.replace(pattern, () => content);
+    if (result.length !== expected) {
+        console.log(`ERROR: "${placeholder}" was not inserted literally`);
+        process.exit(1);
+    }
+    return result;
+}
+
 function apply_replacements (text) {
     const libraryDir = path.resolve(
         __dirname, '..', 'libraries', 'javascript', 'build'
@@ -210,15 +223,14 @@ function apply_replacements (text) {
             );
             process.exit(1);
         }
-        // A replacer function, so $&, $` and $' in a bundle are inserted literally
         const libraryContent = fs.readFileSync(file).toString();
-        text = text.replace(new RegExp(library, 'g'), () => libraryContent);
+        text = insert_literally(text, library, libraryContent);
     }
     const replacements = process.env.REPLACEMENTS.split(' ');
     for (const replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     return text;

--- a/clouds/postgres/common/build_modules.js
+++ b/clouds/postgres/common/build_modules.js
@@ -188,7 +188,9 @@ function apply_replacements (text) {
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            text = text.replace(new RegExp(library, 'g'), libraryContent);
+            // A replacer function, so $&, $` and $' inside a bundle are inserted
+            // literally instead of being expanded as replacement patterns.
+            text = text.replace(new RegExp(library, 'g'), () => libraryContent);
         }
         else {
             console.log(`Warning: library "${libraryName}" does not exist. Run "make build-libraries" with the same filters.`);

--- a/clouds/postgres/common/build_modules.js
+++ b/clouds/postgres/common/build_modules.js
@@ -181,15 +181,27 @@ let content = anonymousBlockWrapping(postgisInstalledCheck)
 // Replace environment variables
 content += output.map(f => anonymousBlockWrapping(extensionFunctionWrapping(f.content, f.module))).join('\n');
 
+// Guards against a future revert to a string replacement, where $& and $$ would expand
+function insert_literally (text, placeholder, content) {
+    const pattern = new RegExp(placeholder, 'g');
+    const count = (text.match(pattern) || []).length;
+    const expected = text.length + count * (content.length - placeholder.length);
+    const result = text.replace(pattern, () => content);
+    if (result.length !== expected) {
+        console.log(`ERROR: "${placeholder}" was not inserted literally`);
+        process.exit(1);
+    }
+    return result;
+}
+
 function apply_replacements (text) {
-    const libraries = [... new Set(text.match(new RegExp('@@PG_LIBRARY_.*@@', 'g')))];
+    const libraries = [... new Set(text.match(new RegExp('@@PG_LIBRARY_[A-Z0-9_]+@@', 'g')))];
     for (let library of libraries) {
         const libraryName = library.replace('@@PG_LIBRARY_', '').replace('@@', '').toLowerCase() + '.js';
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            // A replacer function, so $&, $` and $' in a bundle are inserted literally
-            text = text.replace(new RegExp(library, 'g'), () => libraryContent);
+            text = insert_literally(text, library, libraryContent);
         }
         else {
             console.log(`Warning: library "${libraryName}" does not exist. Run "make build-libraries" with the same filters.`);
@@ -200,7 +212,7 @@ function apply_replacements (text) {
     for (let replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     return text;

--- a/clouds/postgres/common/build_modules.js
+++ b/clouds/postgres/common/build_modules.js
@@ -195,7 +195,7 @@ function insert_literally (text, placeholder, content) {
 }
 
 function apply_replacements (text) {
-    const libraries = [... new Set(text.match(new RegExp('@@PG_LIBRARY_[A-Z0-9_]+@@', 'g')))];
+    const libraries = [... new Set(text.match(new RegExp('@@PG_LIBRARY_[^@]+@@', 'g')))];
     for (let library of libraries) {
         const libraryName = library.replace('@@PG_LIBRARY_', '').replace('@@', '').toLowerCase() + '.js';
         const libraryPath = path.join(libsBuildDir, libraryName);

--- a/clouds/postgres/common/build_modules.js
+++ b/clouds/postgres/common/build_modules.js
@@ -188,8 +188,7 @@ function apply_replacements (text) {
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            // A replacer function, so $&, $` and $' inside a bundle are inserted
-            // literally instead of being expanded as replacement patterns.
+            // A replacer function, so $&, $` and $' in a bundle are inserted literally
             text = text.replace(new RegExp(library, 'g'), () => libraryContent);
         }
         else {

--- a/clouds/postgres/common/list_libraries.js
+++ b/clouds/postgres/common/list_libraries.js
@@ -129,7 +129,7 @@ function add (f, include) {
 functions.forEach(f => add(f));
 
 const content = output.map(f => f.content).join('\n');
-const libraries = [... new Set(content.match(new RegExp('@@PG_LIBRARY_.*@@', 'g')))]
+const libraries = [... new Set(content.match(new RegExp('@@PG_LIBRARY_[^@]+@@', 'g')))]
     .map(l => l.replace('@@PG_LIBRARY_', '').replace('@@', '').toLowerCase());
 
 process.stdout.write(libraries.join(' '));

--- a/clouds/redshift/common/build_modules.js
+++ b/clouds/redshift/common/build_modules.js
@@ -153,7 +153,7 @@ function apply_replacements (text) {
     for (let replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     return text;

--- a/clouds/snowflake/common/build_modules.js
+++ b/clouds/snowflake/common/build_modules.js
@@ -166,7 +166,9 @@ function apply_replacements (text) {
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            text = text.replace(new RegExp(library, 'g'), libraryContent);
+            // A replacer function, so $&, $` and $' inside a bundle are inserted
+            // literally instead of being expanded as replacement patterns.
+            text = text.replace(new RegExp(library, 'g'), () => libraryContent);
         }
         else {
             console.log(`Warning: library "${libraryName}" does not exist. Run "make build-libraries" with the same filters.`);

--- a/clouds/snowflake/common/build_modules.js
+++ b/clouds/snowflake/common/build_modules.js
@@ -159,15 +159,36 @@ if (argv.production) {
 }
 let content = output.map(f => f.content).join(separator);
 
+// Snowflake wraps each JS body in AS $$ ... $$, so a literal $$ in a bundle would close it early
+function inline_library (text, placeholder, content) {
+    if (content.includes('$$')) {
+        console.log(`ERROR: library "${placeholder}" contains "$$", which would close the AS $$ ... $$ body`);
+        process.exit(1);
+    }
+    return insert_literally(text, placeholder, content);
+}
+
+// Guards against a future revert to a string replacement, where $& and $$ would expand
+function insert_literally (text, placeholder, content) {
+    const pattern = new RegExp(placeholder, 'g');
+    const count = (text.match(pattern) || []).length;
+    const expected = text.length + count * (content.length - placeholder.length);
+    const result = text.replace(pattern, () => content);
+    if (result.length !== expected) {
+        console.log(`ERROR: "${placeholder}" was not inserted literally`);
+        process.exit(1);
+    }
+    return result;
+}
+
 function apply_replacements (text) {
-    const libraries = [... new Set(text.match(new RegExp('@@SF_LIBRARY_.*@@', 'g')))];
+    const libraries = [... new Set(text.match(new RegExp('@@SF_LIBRARY_[A-Z0-9_]+@@', 'g')))];
     for (let library of libraries) {
         const libraryName = library.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase() + '.js';
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            // A replacer function, so $&, $` and $' in a bundle are inserted literally
-            text = text.replace(new RegExp(library, 'g'), () => libraryContent);
+            text = inline_library(text, library, libraryContent);
         }
         else {
             console.log(`Warning: library "${libraryName}" does not exist. Run "make build-libraries" with the same filters.`);
@@ -178,7 +199,7 @@ function apply_replacements (text) {
     for (let replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     return text;

--- a/clouds/snowflake/common/build_modules.js
+++ b/clouds/snowflake/common/build_modules.js
@@ -166,8 +166,7 @@ function apply_replacements (text) {
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            // A replacer function, so $&, $` and $' inside a bundle are inserted
-            // literally instead of being expanded as replacement patterns.
+            // A replacer function, so $&, $` and $' in a bundle are inserted literally
             text = text.replace(new RegExp(library, 'g'), () => libraryContent);
         }
         else {

--- a/clouds/snowflake/common/build_modules.js
+++ b/clouds/snowflake/common/build_modules.js
@@ -182,7 +182,7 @@ function insert_literally (text, placeholder, content) {
 }
 
 function apply_replacements (text) {
-    const libraries = [... new Set(text.match(new RegExp('@@SF_LIBRARY_[A-Z0-9_]+@@', 'g')))];
+    const libraries = [... new Set(text.match(new RegExp('@@SF_LIBRARY_[^@]+@@', 'g')))];
     for (let library of libraries) {
         const libraryName = library.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase() + '.js';
         const libraryPath = path.join(libsBuildDir, libraryName);

--- a/clouds/snowflake/common/build_native_app_setup_script.js
+++ b/clouds/snowflake/common/build_native_app_setup_script.js
@@ -9,7 +9,6 @@ const path = require('path');
 const argv = require('minimist')(process.argv.slice(2));
 
 const outputDir = argv.output || 'build';
-const libsBuildDir = argv.libs_build_dir || '../libraries/javascript/build';
 const nativeAppDir = argv.native_app_dir || '../native_app';
 
 // Replace environment variables
@@ -22,25 +21,17 @@ if (argv.production) {
 let content = fs.readFileSync(path.resolve(nativeAppDir, 'SETUP_SCRIPT.sql')).toString();
 
 function apply_replacements (text) {
-    const libraries = [... new Set(text.match(new RegExp('@@SF_LIBRARY_.*@@', 'g')))];
-    for (let library of libraries) {
-        const libraryName = library.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase() + '.js';
-        const libraryPath = path.join(libsBuildDir, libraryName);
-        if (fs.existsSync(libraryPath)) {
-            const libraryContent = fs.readFileSync(libraryPath).toString();
-            // A replacer function, so $&, $` and $' in a bundle are inserted literally
-            text = text.replace(new RegExp(library, 'g'), () => libraryContent);
-        }
-        else {
-            console.log(`Warning: library "${libraryName}" does not exist. Run "make build-libraries" with the same filters.`);
-            process.exit(1);
-        }
+    // The setup script does not inline libraries: modules.sql is read from the stage at install time
+    const libraries = text.match(new RegExp('@@SF_LIBRARY_[A-Z0-9_]+@@', 'g'));
+    if (libraries) {
+        console.log(`ERROR: the setup script cannot inline libraries, found ${libraries.join(', ')}`);
+        process.exit(1);
     }
     const replacements = process.env.REPLACEMENTS.split(' ');
     for (let replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     return text;

--- a/clouds/snowflake/common/build_native_app_setup_script.js
+++ b/clouds/snowflake/common/build_native_app_setup_script.js
@@ -28,8 +28,7 @@ function apply_replacements (text) {
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            // A replacer function, so $&, $` and $' inside a bundle are inserted
-            // literally instead of being expanded as replacement patterns.
+            // A replacer function, so $&, $` and $' in a bundle are inserted literally
             text = text.replace(new RegExp(library, 'g'), () => libraryContent);
         }
         else {

--- a/clouds/snowflake/common/build_native_app_setup_script.js
+++ b/clouds/snowflake/common/build_native_app_setup_script.js
@@ -22,7 +22,7 @@ let content = fs.readFileSync(path.resolve(nativeAppDir, 'SETUP_SCRIPT.sql')).to
 
 function apply_replacements (text) {
     // The setup script does not inline libraries: modules.sql is read from the stage at install time
-    const libraries = text.match(new RegExp('@@SF_LIBRARY_[A-Z0-9_]+@@', 'g'));
+    const libraries = text.match(new RegExp('@@SF_LIBRARY_[^@]+@@', 'g'));
     if (libraries) {
         console.log(`ERROR: the setup script cannot inline libraries, found ${libraries.join(', ')}`);
         process.exit(1);

--- a/clouds/snowflake/common/build_native_app_setup_script.js
+++ b/clouds/snowflake/common/build_native_app_setup_script.js
@@ -28,7 +28,9 @@ function apply_replacements (text) {
         const libraryPath = path.join(libsBuildDir, libraryName);
         if (fs.existsSync(libraryPath)) {
             const libraryContent = fs.readFileSync(libraryPath).toString();
-            text = text.replace(new RegExp(library, 'g'), libraryContent);
+            // A replacer function, so $&, $` and $' inside a bundle are inserted
+            // literally instead of being expanded as replacement patterns.
+            text = text.replace(new RegExp(library, 'g'), () => libraryContent);
         }
         else {
             console.log(`Warning: library "${libraryName}" does not exist. Run "make build-libraries" with the same filters.`);

--- a/clouds/snowflake/common/build_share.js
+++ b/clouds/snowflake/common/build_share.js
@@ -184,7 +184,7 @@ function apply_replacements (text) {
     for (let replacement of replacements) {
         if (replacement) {
             const pattern = new RegExp(`@@${replacement}@@`, 'g');
-            text = text.replace(pattern, process.env[replacement]);
+            text = text.replace(pattern, () => process.env[replacement]);
         }
     }
     return text;

--- a/clouds/snowflake/common/list_libraries.js
+++ b/clouds/snowflake/common/list_libraries.js
@@ -130,7 +130,7 @@ function add (f, include) {
 functions.forEach(f => add(f));
 
 const content = output.map(f => f.content).join('\n');
-const libraries = [... new Set(content.match(new RegExp('@@SF_LIBRARY_.*@@', 'g')))]
+const libraries = [... new Set(content.match(new RegExp('@@SF_LIBRARY_[^@]+@@', 'g')))]
     .map(l => l.replace('@@SF_LIBRARY_', '').replace('@@', '').toLowerCase());
 
 process.stdout.write(libraries.join(' '));

--- a/clouds/snowflake/common/run-script.js
+++ b/clouds/snowflake/common/run-script.js
@@ -66,7 +66,7 @@ function apply_replacements (text) {
         for (let replacement of replacements) {
             if (replacement) {
                 const pattern = new RegExp(`@@${replacement}@@`, 'g');
-                text = text.replace(pattern, process.env[replacement]);
+                text = text.replace(pattern, () => process.env[replacement]);
             }
         }
     }

--- a/clouds/snowflake/modules/Makefile
+++ b/clouds/snowflake/modules/Makefile
@@ -93,7 +93,7 @@ build-native-app-setup-script: $(NODE_MODULES_DEV)
 	SF_APP_SCHEMA=$(SF_UNQUALIFIED_SCHEMA) APP_ROLE=app_public \
 	REPLACEMENTS=$(NATIVE_APP_REPLACEMENTS) \
 	$(COMMON_DIR)/build_native_app_setup_script.js $(MODULES_DIRS) \
-		--output=$(BUILD_DIR) --libs_build_dir=$(LIBS_BUILD_DIR) --native_app_dir=$(NATIVE_APP_DIR) \
+		--output=$(BUILD_DIR) --native_app_dir=$(NATIVE_APP_DIR) \
 		--production=$(production) --dropfirst=1
 
 deploy: check build

--- a/clouds/snowflake/native_app/SETUP_SCRIPT.sql
+++ b/clouds/snowflake/native_app/SETUP_SCRIPT.sql
@@ -35,7 +35,7 @@ AS $$
         ]
 
         for (const [variable, value] of replacements) {
-          modulesSql = modulesSql.replaceAll(variable, () => value);
+          modulesSql = modulesSql.split(variable).join(value);
         }
 
         snowflake.execute({ sqlText: modulesSql });

--- a/clouds/snowflake/native_app/SETUP_SCRIPT.sql
+++ b/clouds/snowflake/native_app/SETUP_SCRIPT.sql
@@ -35,7 +35,7 @@ AS $$
         ]
 
         for (const [variable, value] of replacements) {
-          modulesSql = modulesSql.replaceAll(variable, value);
+          modulesSql = modulesSql.replaceAll(variable, () => value);
         }
 
         snowflake.execute({ sqlText: modulesSql });


### PR DESCRIPTION
## The bug

Snowflake, Postgres and Oracle all inline JavaScript libraries into their SQL with a call of this shape:

```js
text = text.replace(new RegExp(library, 'g'), libraryContent);
```

`String.prototype.replace` treats a **string** replacement as a template, not as literal text: it scans it for `$` directives and expands them. So `$&`, `` $` ``, `$'` and `$$` inside a bundle are interpreted rather than inserted — and `$&` means "the whole match", which here is the placeholder itself.

Passing a replacer function removes the interpretation entirely: the return value is used verbatim.

## What ships today

**Snowflake — real corruption.** `h3_polyfill`, in `bignumber.js`'s number formatter (bundled via `polyclip-ts`):

```js
// source, and what the source map says
f.replace(new RegExp('\\d{' + l + '}\\B', 'g'), '$&' + (t.fractionGroupSeparator || ''))

// what is inlined into modules.sql
f.replace(new RegExp("\\d{"+l+"}\\B","g"),"@@SF_LIBRARY_H3_POLYFILL@@"+(t.fractionGroupSeparator||""))
```

In the public `H3_POLYFILL` function. **No known runtime impact** — the branch needs `toFormat` with `fractionGroupSize`, and `polyclip-ts` never formats numbers for display, so it is unreachable in practice.

In production since **2025-10-23**, commit `cba3b123` *"fix(bq,sf): update turf version (#564)"* — turf 7 replaced `turf-jsts` with `polyclip-ts`, which brought `bignumber.js` in. Confirmed in a package built 2026-06-15. The mechanism itself dates to `8e7f813d` (2022-08-31) but stayed latent until a bundled dependency happened to contain `$&`.

**Postgres and Oracle — latent.** Same call, no manifestation today: Postgres is on turf 6.3.0 with no `bignumber.js` in its tree and a clean `h3.js`; Oracle's `h3.js` and `quadbin.js` are clean too. They are included because Snowflake's instance became real through a *routine dependency bump*, not a code change — the same upgrade in either cloud would silently reintroduce it.

**BigQuery — deliberately unchanged.** Its substitution inserts a GCS bucket path rather than code, because BigQuery loads the JavaScript from a bucket instead of inlining it. No exposure, and no reason to re-test a cloud that has none.

**Redshift and Databricks** have no JavaScript libraries at all.

`$1`-`$9` were always left literal because the pattern has no capture groups, which is why the `$N` sequence in the `statistics` bundle was never affected. Luck rather than design — adding a capture group to that regex would have started corrupting it too.

## Verification

**Snowflake** (`make build`, premium package):
- `h3_polyfill` as inlined in the generated `modules.sql` is now **byte-identical** to `libraries/javascript/build/h3_polyfill.js` (114,315 bytes both)
- `"$&"` present in the inlined bundle; no `@@SF_LIBRARY_H3_POLYFILL@@` inside any JS body
- zero unresolved `@@SF_LIBRARY_*@@` placeholders left in `modules.sql`

**Postgres and Oracle** — proof of no behavioural change: `modules.sql` built before and after the fix is **byte-identical** for both clouds (postgres 2,232,427 B, oracle 195,122 B, same sha256 either way). Expected, since neither has a `$` sequence in any bundle, but worth demonstrating rather than assuming.

`lint-common` clean for all three clouds. AT is being probed against this branch in CartoDB/analytics-toolbox#1188, where the premium modules inline 14 further libraries.

## How it was found

The source review index in #649 hashes each bundle; verifying those hashes against the bytes actually inlined in `modules.sql` failed for `h3_polyfill` and pointed straight at the expansion. (`tiler_simple` mismatched too, but legitimately — it embeds `@@SF_PACKAGE_VERSION@@`, substituted after inlining. #649 was updated to hash the shipped files instead.)

Beyond the corruption itself, this matters for #649: once source maps ship, a reviewer comparing a map's `sourcesContent` against `modules.sql` would find the readable source disagreeing with the shipped bundle — exactly the correspondence the maps exist to demonstrate to Snowflake's security review.

Story: sc-572077

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Added in review

The first pass fixed only library inlining, in only three clouds. [Jesús's review](https://github.com/CartoDB/analytics-toolbox-core/pull/650#pullrequestreview-5130556653) found the class was wider and one instance was live.

**The live one.** `native_app/SETUP_SCRIPT.sql:38` substitutes `@@SF_SCHEMA@@` for the caller-supplied `DESTINATION_SCHEMA`, in the `INSTALL` procedure that runs **in the consumer's account**. `$` is legal in an unquoted Snowflake identifier, so `$$` is reachable with a valid name and halves to `$`; `$&` puts the placeholder back unresolved into SQL that `snowflake.execute` then runs. Fixed here and, for the copy the premium package ships, in [analytics-toolbox#1193](https://github.com/CartoDB/analytics-toolbox/pull/1193).

**The rest of the class.** Env-var replacements in `snowflake`, `postgres`, `oracle`, `bigquery`, `databricks` and `redshift` `build_modules`, in `build_share`, and in both `run-script`s — ten sites. The first pass fixed eight and missed `databricks` and `redshift`; corrected after review. BigQuery's library inlining too, which also carried real drift: `apply_replacements(text)` scanned `content`, an outer variable, instead of its own parameter.

**Dead code removed.** No `.sql` input carries a `@@SF_LIBRARY_*@@` placeholder in either repo, so the loop in `build_native_app_setup_script.js` was unreachable. It is now a guard that fails loudly if one is ever added, and its `--libs_build_dir` argument is gone from the script and the Makefile.

**Two new guards.** Going literal means a `$$` inside a bundle would now close an `AS $$ … $$` body — Snowflake only, since Postgres dollar-quotes with `$BODY$` and Oracle puts raw JS after `LANGUAGE JAVASCRIPT AS`. 0 occurrences across the 25 core bundles today, so it is forward-looking, and the build now rejects it. Every inlining also checks the inserted byte count, which catches a revert to a string replacement.

**Bounded the placeholder patterns.** `@@SF_LIBRARY_.*@@` is greedy and collapses two placeholders on one line into a single bogus match; Oracle already used the bounded form. 0 such lines today — the same latent-risk argument this PR makes for PG and ORA.

**Not done here: deduplicating `apply_replacements`.** Six copies that have drifted is the root cause, but they are not interchangeable — BigQuery substitutes a bucket path and strips `@@SKIP_DEP@@`, Snowflake needs a `$$` rejection that would be wrong elsewhere, Oracle resolves its own library directory. That is a refactor across four clouds' build paths, and it belongs in its own story rather than inside a correctness fix.

## Verification

The CI evidence originally posted here was **invalid and has been retracted**: analytics-toolbox#1188 changed three READMEs and the submodule pointer, matched no path filter, and `if (diffModulesFilter)` is truthy on `[]`, so zero functions were built — the runs took ~2m11s against ~17min for a real one. Replaced with a local premium build against this branch:

```
491 functions built            (the probe built 0)
0   unresolved placeholders
3   literal "$&" occurrences
h3_polyfill inlined as:  "$&"+(t.fractionGroupSeparator||"))
                previously:  "@@SF_LIBRARY_H3_POLYFILL@@"+(t.fractionGroupSeparator||"")
```

Both guards were tested by deliberately triggering them, Postgres and Oracle build clean, BigQuery's `accessors.js` warning reproduces identically on `origin/main` (a missing local bundle, not this change), and eslint is clean across all eight files.

Merges cleanly with #649 — they share only `clouds/snowflake/modules/Makefile`, which auto-merges.



---

## Added in the second review round

Jesús checked `2a119db4` and found two gaps plus two forward-looking notes. All addressed:

- **`databricks:167` and `redshift:156`** carried the same string replacement, so "eight sites" was eight of ten. Fixed; no occurrence of that pattern remains anywhere in `clouds/`.
- **`SETUP_SCRIPT.sql:38` is the only runtime change here and nothing exercised it** — it runs in Snowflake's JavaScript engine at install time, so the replacer form rested on the *function* overload of `replaceAll` behaving there, which `replaceAll`-with-a-string being in production does not prove. Switched to `split(variable).join(value)`, which is literal by construction and needs no assumption about engine support. Verified identical output to the replacer for `$$`, `$&` and a plain name. Same change in [analytics-toolbox#1193](https://github.com/CartoDB/analytics-toolbox/pull/1193).
- **The bounded pattern narrowed the character class, not just the greed.** `@@SF_LIBRARY_H3-POLY@@` matches `.*@@` but not `[A-Z0-9_]+@@`, and that miss is silent — a placeholder that never enters the `libraries` list gets no "does not exist" warning and ships unresolved. Now `[^@]+` in every scanner: `build_modules` and `list_libraries` for Snowflake and Postgres, the setup-script guard, and **Oracle**, which already had the narrowed class and is where the pattern was copied from.
- **`$$` at the installer site stays unguarded**, as agreed — still strictly better than the previous silent `$$` → `$` halving, and a loud SQL error rather than a wrong schema.

Follow-up filed for the root cause, as requested: **[sc-572754](https://app.shortcut.com/cartoteam/story/572754)** — deduplicate `apply_replacements`, including the `insert_literally` copies this PR adds, and the note that no CI path currently exercises the premium modules.
